### PR TITLE
fix: `cookieSecure` config + NODE_ENV default (closes #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.30.0",
+	"version": "0.31.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/credentials/config.ts
+++ b/src/credentials/config.ts
@@ -101,5 +101,6 @@ export type CredentialsConfig<UserType> = {
 // to persist promoted sessions, so they accept this superset of the public config.
 export type CredentialRouteProps<UserType> = CredentialsConfig<UserType> & {
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 	lockoutGuard?: LockoutGuard;
 };

--- a/src/credentials/login.ts
+++ b/src/credentials/login.ts
@@ -7,6 +7,7 @@ import { createSessionCompatibilityLayer } from '../session/access';
 import { persistWhen, promoteToSession } from '../session/promote';
 import { sessionStore } from '../session/state';
 import { userSessionIdTypebox } from '../typebox';
+import { resolveCookieSecure } from '../utils';
 import {
 	type CredentialRouteProps,
 	DEFAULT_CREDENTIAL_SESSION_TTL_MS
@@ -16,6 +17,7 @@ import { isPasswordCompromised } from './passwordPolicy';
 export const credentialsLogin = <UserType>({
 	authSessionStore,
 	checkBreachesOnLogin,
+	cookieSecure,
 	credentialStore,
 	getUserByEmail,
 	isMfaRequired,
@@ -134,7 +136,7 @@ export const credentialsLogin = <UserType>({
 				user_session_id.set({
 					httpOnly: true,
 					sameSite: 'lax',
-					secure: true,
+					secure: resolveCookieSecure(cookieSecure),
 					value: pendingSessionId
 				});
 				await persistWhen(
@@ -154,6 +156,7 @@ export const credentialsLogin = <UserType>({
 			const userSessionId = await promoteToSession({
 				authSessionStore,
 				cookie: user_session_id,
+				cookieSecure,
 				inMemorySession: session,
 				sessionDurationMs,
 				user

--- a/src/credentials/register.ts
+++ b/src/credentials/register.ts
@@ -13,6 +13,7 @@ import { evaluatePassword } from './passwordPolicy';
 
 export const credentialsRegister = <UserType>({
 	authSessionStore,
+	cookieSecure,
 	credentialStore,
 	onCreateCredentialUser,
 	onCredentialsLoginSuccess,
@@ -96,6 +97,7 @@ export const credentialsRegister = <UserType>({
 			const userSessionId = await promoteToSession({
 				authSessionStore,
 				cookie: user_session_id,
+				cookieSecure,
 				inMemorySession: session,
 				sessionDurationMs,
 				user: created

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,12 @@ import { samlSsoRoutes } from './sso/samlRoutes';
 import { webauthnRoutes } from './webauthn/routes';
 import { createWebhookDispatcher } from './webhooks/dispatcher';
 import { AuthConfig, ClientProviders } from './types';
+import { resolveCookieSecure } from './utils';
 
 export const auth = async <UserType>({
 	providersConfiguration,
 	authorizeRoute,
+	cookieSecure,
 	callbackRoute,
 	profileRoute,
 	signoutRoute,
@@ -96,6 +98,7 @@ export const auth = async <UserType>({
 		providersConfiguration,
 		createOAuth2Client
 	);
+	const resolvedCookieSecure = resolveCookieSecure(cookieSecure);
 
 	// `webhooks` forwards every emitted event; composing it into the audit emitter means
 	// configuring webhooks alone (without `audit`) is enough to turn on event emission.
@@ -183,6 +186,7 @@ export const auth = async <UserType>({
 			authorize({
 				authorizeRoute,
 				clientProviders,
+				cookieSecure: resolvedCookieSecure,
 				onAuthorizeError,
 				onAuthorizeSuccess
 			})
@@ -213,13 +217,18 @@ export const auth = async <UserType>({
 				? credentialRoutes<UserType>({
 						...auditedCredentials,
 						authSessionStore,
+						cookieSecure: resolvedCookieSecure,
 						lockoutGuard
 					})
 				: new Elysia()
 		)
 		.use(
 			auditedMfa
-				? mfaRoutes<UserType>({ ...auditedMfa, authSessionStore })
+				? mfaRoutes<UserType>({
+						...auditedMfa,
+						authSessionStore,
+						cookieSecure: resolvedCookieSecure
+					})
 				: new Elysia()
 		)
 		.use(
@@ -227,6 +236,7 @@ export const auth = async <UserType>({
 				? passwordlessRoutes<UserType>({
 						...passwordless,
 						authSessionStore,
+						cookieSecure: resolvedCookieSecure,
 						emit: auditEmit
 					})
 				: new Elysia()
@@ -238,7 +248,11 @@ export const auth = async <UserType>({
 		)
 		.use(
 			sso
-				? oidcSsoRoutes<UserType>({ ...sso, authSessionStore })
+				? oidcSsoRoutes<UserType>({
+						...sso,
+						authSessionStore,
+						cookieSecure: resolvedCookieSecure
+					})
 				: new Elysia()
 		)
 		.use(
@@ -246,6 +260,7 @@ export const auth = async <UserType>({
 				? samlSsoRoutes<UserType>({
 						...sso,
 						authSessionStore,
+						cookieSecure: resolvedCookieSecure,
 						samlAdapter: sso.samlAdapter
 					})
 				: new Elysia()
@@ -293,6 +308,7 @@ export const auth = async <UserType>({
 				? webauthnRoutes<UserType>({
 						...webauthn,
 						authSessionStore,
+						cookieSecure: resolvedCookieSecure,
 						emit: auditEmit
 					})
 				: new Elysia()

--- a/src/mfa/challenge.ts
+++ b/src/mfa/challenge.ts
@@ -4,6 +4,7 @@ import { createSessionCompatibilityLayer } from '../session/access';
 import { persistWhen } from '../session/promote';
 import { sessionStore } from '../session/state';
 import { userSessionIdTypebox } from '../typebox';
+import { resolveCookieSecure } from '../utils';
 import { consumeBackupCode } from './backupCodes';
 import { DEFAULT_MFA_SESSION_TTL_MS, type MfaRouteProps } from './config';
 import { decryptTotpSecret } from './secret';
@@ -11,6 +12,7 @@ import { decryptTotpSecret } from './secret';
 export const mfaChallenge = <UserType>({
 	authSessionStore,
 	challengeRoute = '/auth/mfa/challenge',
+	cookieSecure,
 	encryptionKey,
 	getChallengeUser,
 	getUserId,
@@ -94,7 +96,7 @@ export const mfaChallenge = <UserType>({
 			user_session_id.set({
 				httpOnly: true,
 				sameSite: 'lax',
-				secure: true,
+				secure: resolveCookieSecure(cookieSecure),
 				value: userSessionId
 			});
 			await persistWhen(

--- a/src/mfa/config.ts
+++ b/src/mfa/config.ts
@@ -38,4 +38,5 @@ export type MfaConfig<UserType> = {
 
 export type MfaRouteProps<UserType> = MfaConfig<UserType> & {
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 };

--- a/src/passwordless/config.ts
+++ b/src/passwordless/config.ts
@@ -59,5 +59,6 @@ export type PasswordlessConfig<UserType> = {
 
 export type PasswordlessRouteProps<UserType> = PasswordlessConfig<UserType> & {
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 	emit?: AuditEmitter;
 };

--- a/src/passwordless/routes.ts
+++ b/src/passwordless/routes.ts
@@ -31,6 +31,7 @@ const generateOtpCode = (length: number) => {
 // mounts this before `protectRoutePlugin` when a `passwordless` block is supplied.
 export const passwordlessRoutes = <UserType>({
 	authSessionStore,
+	cookieSecure,
 	emit,
 	getUserByEmail,
 	getUserId,
@@ -64,6 +65,7 @@ export const passwordlessRoutes = <UserType>({
 		const userSessionId = await promoteToSession({
 			authSessionStore,
 			cookie: userSessionCookie,
+			cookieSecure,
 			inMemorySession: session,
 			sessionDurationMs,
 			user

--- a/src/routes/authorize.ts
+++ b/src/routes/authorize.ts
@@ -18,10 +18,12 @@ import {
 	OnAuthorizeError,
 	OnAuthorizeSuccess
 } from '../types';
+import { resolveCookieSecure } from '../utils';
 
 type AuthorizeProps = {
 	clientProviders: ClientProviders;
 	authorizeRoute?: AuthorizeRoute;
+	cookieSecure?: boolean;
 	onAuthorizeSuccess: OnAuthorizeSuccess;
 	onAuthorizeError: OnAuthorizeError;
 };
@@ -45,10 +47,13 @@ const parseReferer = (headerReferer: string | undefined) => {
 export const authorize = ({
 	clientProviders,
 	authorizeRoute = '/oauth2/:provider/authorization',
+	cookieSecure,
 	onAuthorizeSuccess,
 	onAuthorizeError
-}: AuthorizeProps) =>
-	new Elysia().get(
+}: AuthorizeProps) => {
+	const secure = resolveCookieSecure(cookieSecure);
+
+	return new Elysia().get(
 		authorizeRoute,
 		async ({
 			status,
@@ -97,7 +102,7 @@ export const authorize = ({
 				maxAge: COOKIE_DURATION,
 				path: '/',
 				sameSite: 'lax',
-				secure: true,
+				secure,
 				value: referer
 			});
 
@@ -106,7 +111,7 @@ export const authorize = ({
 				maxAge: COOKIE_DURATION,
 				path: '/',
 				sameSite: 'lax',
-				secure: true,
+				secure,
 				value: provider
 			});
 
@@ -115,7 +120,7 @@ export const authorize = ({
 				maxAge: COOKIE_DURATION,
 				path: '/',
 				sameSite: 'lax',
-				secure: true,
+				secure,
 				value: clientName ?? ''
 			});
 
@@ -125,7 +130,7 @@ export const authorize = ({
 					maxAge: COOKIE_DURATION,
 					path: '/',
 					sameSite: 'lax',
-					secure: true,
+					secure,
 					value: authIntent
 				});
 			} else {
@@ -138,7 +143,7 @@ export const authorize = ({
 				maxAge: COOKIE_DURATION,
 				path: '/',
 				sameSite: 'lax',
-				secure: true,
+				secure,
 				value: currentState
 			});
 
@@ -152,7 +157,7 @@ export const authorize = ({
 					maxAge: COOKIE_DURATION,
 					path: '/',
 					sameSite: 'lax',
-					secure: true,
+					secure,
 					value: codeVerifier
 				});
 			}
@@ -215,3 +220,4 @@ export const authorize = ({
 			})
 		}
 	);
+};

--- a/src/session/anonymous.ts
+++ b/src/session/anonymous.ts
@@ -14,12 +14,14 @@ const DEFAULT_GUEST_TTL_MS = MILLISECONDS_IN_A_DAY;
 export const createAnonymousSession = async <UserType>({
 	authSessionStore,
 	cookie,
+	cookieSecure,
 	guestUser,
 	inMemorySession,
 	sessionDurationMs = DEFAULT_GUEST_TTL_MS
 }: {
 	authSessionStore?: AuthSessionStore<UserType>;
 	cookie: Cookie<UserSessionId | undefined>;
+	cookieSecure?: boolean;
 	guestUser: UserType;
 	inMemorySession: SessionRecord<UserType>;
 	sessionDurationMs?: number;
@@ -28,6 +30,7 @@ export const createAnonymousSession = async <UserType>({
 		anonymous: true,
 		authSessionStore,
 		cookie,
+		cookieSecure,
 		inMemorySession,
 		sessionDurationMs,
 		user: guestUser

--- a/src/session/impersonation.ts
+++ b/src/session/impersonation.ts
@@ -7,6 +7,7 @@ import type {
 	SessionRecord,
 	UserSessionId
 } from '../types';
+import { resolveCookieSecure } from '../utils';
 import { loadSessionFromSource } from './access';
 import { promoteToSession } from './promote';
 import type { AuthSessionStore } from './types';
@@ -21,11 +22,13 @@ type Emit = (event: AuditEvent) => Promise<void> | void;
 export const endImpersonation = async <UserType>({
 	authSessionStore,
 	cookie,
+	cookieSecure,
 	emit,
 	inMemorySession
 }: {
 	authSessionStore?: AuthSessionStore<UserType>;
 	cookie: Cookie<UserSessionId | undefined>;
+	cookieSecure?: boolean;
 	emit?: Emit;
 	inMemorySession: SessionRecord<UserType>;
 }) => {
@@ -65,7 +68,7 @@ export const endImpersonation = async <UserType>({
 		cookie.set({
 			httpOnly: true,
 			sameSite: 'lax',
-			secure: true,
+			secure: resolveCookieSecure(cookieSecure),
 			value: returnTo
 		});
 
@@ -91,6 +94,7 @@ export const isImpersonating = <UserType>(
 export const startImpersonation = async <UserType>({
 	authSessionStore,
 	cookie,
+	cookieSecure,
 	emit,
 	getUserId,
 	impersonator,
@@ -100,6 +104,7 @@ export const startImpersonation = async <UserType>({
 }: {
 	authSessionStore?: AuthSessionStore<UserType>;
 	cookie: Cookie<UserSessionId | undefined>;
+	cookieSecure?: boolean;
 	emit?: Emit;
 	getUserId?: (user: UserType) => string;
 	impersonator: { actorEmail?: string; actorId: string; reason: string };
@@ -119,6 +124,7 @@ export const startImpersonation = async <UserType>({
 	const sessionId = await promoteToSession({
 		authSessionStore,
 		cookie,
+		cookieSecure,
 		impersonator: stamp,
 		inMemorySession,
 		sessionDurationMs,

--- a/src/session/multiSession.ts
+++ b/src/session/multiSession.ts
@@ -1,6 +1,7 @@
 import type { Cookie } from 'elysia';
 import { isUserSessionId } from '../typeGuards';
 import type { SessionRecord, UserSessionId } from '../types';
+import { resolveCookieSecure } from '../utils';
 import { loadSessionFromSource } from './access';
 import type { AuthSessionStore } from './types';
 
@@ -12,11 +13,15 @@ import type { AuthSessionStore } from './types';
 
 const SEPARATOR = ' ';
 
-const writeRing = (ring: Cookie<string | undefined>, ids: UserSessionId[]) =>
+const writeRing = (
+	ring: Cookie<string | undefined>,
+	ids: UserSessionId[],
+	cookieSecure?: boolean
+) =>
 	ring.set({
 		httpOnly: true,
 		sameSite: 'lax',
-		secure: true,
+		secure: resolveCookieSecure(cookieSecure),
 		value: ids.join(SEPARATOR)
 	});
 
@@ -27,8 +32,14 @@ const readRing = (ring: Cookie<string | undefined>) =>
 
 export const addToSessionRing = (
 	ring: Cookie<string | undefined>,
-	sessionId: UserSessionId
-) => writeRing(ring, [...new Set([...readRing(ring), sessionId])]);
+	sessionId: UserSessionId,
+	cookieSecure?: boolean
+) =>
+	writeRing(
+		ring,
+		[...new Set([...readRing(ring), sessionId])],
+		cookieSecure
+	);
 
 // Resolve the ring to its still-valid sessions (for an account switcher). Drops expired ones.
 export const listRingSessions = async <UserType>({
@@ -69,18 +80,20 @@ export const readSessionRing = (ring: Cookie<string | undefined>) =>
 export const removeFromSessionRing = async <UserType>({
 	activeCookie,
 	authSessionStore,
+	cookieSecure,
 	inMemorySession,
 	ring,
 	sessionId
 }: {
 	activeCookie?: Cookie<UserSessionId | undefined>;
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 	inMemorySession?: SessionRecord<UserType>;
 	ring: Cookie<string | undefined>;
 	sessionId: UserSessionId;
 }) => {
 	const remaining = readRing(ring).filter((id) => id !== sessionId);
-	writeRing(ring, remaining);
+	writeRing(ring, remaining, cookieSecure);
 	if (authSessionStore) await authSessionStore.removeSession(sessionId);
 	else if (inMemorySession) delete inMemorySession[sessionId];
 
@@ -91,7 +104,7 @@ export const removeFromSessionRing = async <UserType>({
 		activeCookie.set({
 			httpOnly: true,
 			sameSite: 'lax',
-			secure: true,
+			secure: resolveCookieSecure(cookieSecure),
 			value: fallback
 		});
 };
@@ -99,10 +112,12 @@ export const removeFromSessionRing = async <UserType>({
 // Make a ring member the active session. Returns false if it isn't in the ring.
 export const switchActiveSession = ({
 	activeCookie,
+	cookieSecure,
 	ring,
 	sessionId
 }: {
 	activeCookie: Cookie<UserSessionId | undefined>;
+	cookieSecure?: boolean;
 	ring: Cookie<string | undefined>;
 	sessionId: UserSessionId;
 }) => {
@@ -110,7 +125,7 @@ export const switchActiveSession = ({
 	activeCookie.set({
 		httpOnly: true,
 		sameSite: 'lax',
-		secure: true,
+		secure: resolveCookieSecure(cookieSecure),
 		value: sessionId
 	});
 

--- a/src/session/promote.ts
+++ b/src/session/promote.ts
@@ -1,5 +1,6 @@
 import type { Cookie } from 'elysia';
 import type { SessionData, SessionRecord, UserSessionId } from '../types';
+import { resolveCookieSecure } from '../utils';
 import { createSessionCompatibilityLayer } from './access';
 import type { AuthSessionStore } from './types';
 
@@ -51,6 +52,7 @@ type PromoteToSessionProps<UserType> = {
 	anonymous?: boolean;
 	authSessionStore?: AuthSessionStore<UserType>;
 	cookie: Cookie<UserSessionId | undefined>;
+	cookieSecure?: boolean;
 	impersonator?: SessionData<UserType>['impersonator'];
 	inMemorySession: SessionRecord<UserType>;
 	samlLogout?: SessionData<UserType>['samlLogout'];
@@ -66,6 +68,7 @@ export const promoteToSession = async <UserType>({
 	anonymous,
 	authSessionStore,
 	cookie,
+	cookieSecure,
 	impersonator,
 	inMemorySession,
 	samlLogout,
@@ -93,7 +96,7 @@ export const promoteToSession = async <UserType>({
 	cookie.set({
 		httpOnly: true,
 		sameSite: 'lax',
-		secure: true,
+		secure: resolveCookieSecure(cookieSecure),
 		value: userSessionId
 	});
 

--- a/src/sso/oidcRoutes.ts
+++ b/src/sso/oidcRoutes.ts
@@ -7,6 +7,7 @@ import type { AuthSessionStore } from '../session/types';
 import { isNonEmptyString } from '../typeGuards';
 import { userSessionIdTypebox } from '../typebox';
 import type { RouteString } from '../types';
+import { resolveCookieSecure } from '../utils';
 import {
 	DEFAULT_SSO_ROUTE,
 	DEFAULT_SSO_SESSION_TTL_MS,
@@ -16,21 +17,24 @@ import {
 
 type OidcRoutesProps<UserType> = SSOConfig<UserType> & {
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 };
 
-const ssoCookieOptions: {
+type SsoCookieOptions = {
 	httpOnly: boolean;
 	maxAge: number;
 	path: string;
 	sameSite: 'lax';
 	secure: boolean;
-} = {
+};
+
+const makeSsoCookieOptions = (secure: boolean): SsoCookieOptions => ({
 	httpOnly: true,
 	maxAge: COOKIE_DURATION,
 	path: '/',
 	sameSite: 'lax',
-	secure: true
-};
+	secure
+});
 
 const ssoCookieSchema = t.Cookie({
 	sso_nonce: t.Optional(t.String()),
@@ -57,6 +61,7 @@ const parseReferer = (referer: string | undefined) => {
 
 export const oidcSsoRoutes = <UserType>({
 	authSessionStore,
+	cookieSecure,
 	getSsoUser,
 	onSsoCallbackError,
 	onSsoCallbackSuccess,
@@ -64,6 +69,9 @@ export const oidcSsoRoutes = <UserType>({
 	ssoConnectionStore,
 	ssoRoute = DEFAULT_SSO_ROUTE
 }: OidcRoutesProps<UserType>) => {
+	const ssoCookieOptions = makeSsoCookieOptions(
+		resolveCookieSecure(cookieSecure)
+	);
 	const authorizeRoute: RouteString = `${ssoRoute}/oidc/:organizationId/authorize`;
 	const callbackRoute: RouteString = `${ssoRoute}/oidc/:organizationId/callback`;
 
@@ -219,6 +227,7 @@ export const oidcSsoRoutes = <UserType>({
 					const userSessionId = await promoteToSession({
 						authSessionStore,
 						cookie: user_session_id,
+						cookieSecure,
 						inMemorySession: session,
 						sessionDurationMs,
 						user

--- a/src/sso/samlRoutes.ts
+++ b/src/sso/samlRoutes.ts
@@ -16,6 +16,7 @@ import {
 
 type SamlRoutesProps<UserType> = SSOConfig<UserType> & {
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 	samlAdapter: SamlAdapter;
 };
 
@@ -49,6 +50,7 @@ const settle = async <Value>(work: Value | Promise<Value>) => {
 
 export const samlSsoRoutes = <UserType>({
 	authSessionStore,
+	cookieSecure,
 	getSsoUser,
 	onSsoCallbackError,
 	onSsoCallbackSuccess,
@@ -162,6 +164,7 @@ export const samlSsoRoutes = <UserType>({
 					const userSessionId = await promoteToSession({
 						authSessionStore,
 						cookie: user_session_id,
+						cookieSecure,
 						inMemorySession: session,
 						samlLogout: {
 							connectionId: connection.connectionId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,14 @@ export type AuthorizeRoute = `${string}/:provider${'' | `/${string}`}`;
 
 export type AuthConfig<UserType> = {
 	providersConfiguration: OAuth2ConfigurationOptions;
+	/** Override the `Secure` attribute on every cookie the package sets (session, OAuth state,
+	 *  code_verifier, SSO nonce, ring, etc.). When omitted, defaults to
+	 *  `process.env.NODE_ENV === 'production'` — matching the convention used by
+	 *  express-session / iron-session / lucia / better-auth, and the only way non-browser
+	 *  HTTP clients (curl, SSR fetch, test runners) can round-trip cookies on a plain-HTTP
+	 *  dev server. If you run prod without setting `NODE_ENV=production`, set
+	 *  `cookieSecure: true` explicitly. */
+	cookieSecure?: boolean;
 	authorizeRoute?: AuthorizeRoute;
 	profileRoute?: RouteString;
 	callbackRoute?: RouteString;
@@ -511,6 +519,7 @@ export type InsantiateUserSessionProps<UserType> = {
 	user_session_id: Cookie<UserSessionId | undefined>;
 	onNewUser: OnNewUser<UserType>;
 	getUser: GetUser<UserType>;
+	cookieSecure?: boolean;
 	resolvedAuthorization?: ResolvedOAuthAuthorization;
 	sessionDurationMs?: number;
 	unregisteredSessionDurationMs?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,7 @@ export const getStatus = async <UserType>(
 };
 export const instantiateUserSession = async <UserType>({
 	authProvider,
+	cookieSecure,
 	session,
 	user_session_id,
 	unregisteredSession,
@@ -75,6 +76,7 @@ export const instantiateUserSession = async <UserType>({
 
 	const userSession = validateSession({ session, user_session_id });
 	const userSessionId = getUserSessionId({
+		cookieSecure,
 		session,
 		unregisteredSession,
 		user_session_id
@@ -121,6 +123,15 @@ export const instantiateUserSession = async <UserType>({
 
 	return response;
 };
+// Cookie Secure flag resolution. Default convention: only set Secure=true in production
+// (matches express-session, iron-session, lucia, better-auth). Hardcoding Secure=true broke
+// non-browser HTTP clients (curl, SSR fetch, Playwright API contexts, test runners) on
+// http://localhost in dev, because they don't honor the browser's "localhost is a secure
+// context" exemption. An explicit `cookieSecure` on AuthConfig overrides; otherwise we
+// look at NODE_ENV. Consumers running prod without NODE_ENV=production should set
+// `cookieSecure: true` explicitly.
+export const resolveCookieSecure = (override?: boolean) =>
+	override ?? process.env.NODE_ENV === 'production';
 export const resolveOAuthAuthorization = async ({
 	authProvider,
 	providerInstance,
@@ -230,6 +241,7 @@ export const validateSession = <
 };
 
 type GetUserSessionIdProps<UserType> = {
+	cookieSecure?: boolean;
 	user_session_id: Cookie<UserSessionId | undefined>;
 	session?: SessionRecord<UserType>;
 	unregisteredSession?: UnregisteredSessionRecord;
@@ -245,6 +257,7 @@ const clearExistingSession = <UserType>(
 };
 
 export const getUserSessionId = <UserType>({
+	cookieSecure,
 	user_session_id,
 	session,
 	unregisteredSession
@@ -260,7 +273,7 @@ export const getUserSessionId = <UserType>({
 	user_session_id.set({
 		httpOnly: true,
 		sameSite: 'lax',
-		secure: true,
+		secure: resolveCookieSecure(cookieSecure),
 		value: userSessionId
 	});
 

--- a/src/webauthn/config.ts
+++ b/src/webauthn/config.ts
@@ -49,6 +49,7 @@ export type WebAuthnConfig<UserType> = {
 
 export type WebAuthnRouteProps<UserType> = WebAuthnConfig<UserType> & {
 	authSessionStore?: AuthSessionStore<UserType>;
+	cookieSecure?: boolean;
 	// When `auth()` has an audit block, registration / authentication emit audit events.
 	emit?: AuditEmitter;
 };

--- a/src/webauthn/routes.ts
+++ b/src/webauthn/routes.ts
@@ -5,6 +5,7 @@ import { promoteToSession } from '../session/promote';
 import { sessionStore } from '../session/state';
 import { isNonEmptyString } from '../typeGuards';
 import { userSessionIdTypebox } from '../typebox';
+import { resolveCookieSecure } from '../utils';
 import {
 	DEFAULT_WEBAUTHN_CHALLENGE_TTL_MS,
 	DEFAULT_WEBAUTHN_ROUTE,
@@ -19,6 +20,7 @@ import {
 export const webauthnRoutes = <UserType>({
 	authSessionStore,
 	challengeDurationMs = DEFAULT_WEBAUTHN_CHALLENGE_TTL_MS,
+	cookieSecure,
 	credentialStore,
 	emit,
 	getUserDisplayName,
@@ -34,6 +36,7 @@ export const webauthnRoutes = <UserType>({
 	webauthnAdapter,
 	webauthnRoute = DEFAULT_WEBAUTHN_ROUTE
 }: WebAuthnRouteProps<UserType>) => {
+	const secure = resolveCookieSecure(cookieSecure);
 	const challengeCookie = t.Cookie({
 		user_session_id: t.Optional(userSessionIdTypebox),
 		webauthn_challenge: t.Optional(t.String())
@@ -46,7 +49,7 @@ export const webauthnRoutes = <UserType>({
 			httpOnly: true,
 			maxAge: Math.floor(challengeDurationMs / MILLISECONDS_IN_A_SECOND),
 			sameSite: 'lax',
-			secure: true,
+			secure,
 			value: challenge
 		});
 
@@ -227,6 +230,7 @@ export const webauthnRoutes = <UserType>({
 				const userSessionId = await promoteToSession({
 					authSessionStore,
 					cookie: user_session_id,
+					cookieSecure,
 					inMemorySession: session,
 					sessionDurationMs,
 					user

--- a/tests/cookieSecure.test.ts
+++ b/tests/cookieSecure.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import type {
+	CredentialEmailMessage,
+	CredentialsConfig
+} from '../src/credentials/config';
+import { credentialsLogin } from '../src/credentials/login';
+import { credentialsRegister } from '../src/credentials/register';
+import { createInMemoryCredentialStore } from '../src/credentials/inMemoryCredentialStore';
+import { resolveCookieSecure } from '../src/utils';
+
+// Repros issue #6: the `Secure` flag was hardcoded to true on every cookie the package
+// set, which broke non-browser HTTP clients (curl, SSR fetch, test runners) trying to
+// round-trip a session on http://localhost in dev. The fix: default to NODE_ENV ===
+// 'production', and let consumers override via `cookieSecure`.
+
+type TestUser = { email: string; sub: string };
+
+const buildLoginApp = (cookieSecure?: boolean) => {
+	const credentialStore = createInMemoryCredentialStore();
+	const users = new Map<string, TestUser>();
+	const config: CredentialsConfig<TestUser> = {
+		credentialStore,
+		getUserByEmail: (email) => users.get(email) ?? null,
+		onCreateCredentialUser: ({ email }) => {
+			const user: TestUser = { email, sub: `user:${email}` };
+			users.set(email, user);
+
+			return user;
+		},
+		onSendEmail: (_message: CredentialEmailMessage) => undefined,
+		passwordPolicy: { minLength: 8 }
+	};
+
+	return new Elysia()
+		.use(credentialsRegister({ ...config, cookieSecure }))
+		.use(credentialsLogin({ ...config, cookieSecure }));
+};
+
+const registerAndLogin = async (
+	app: { handle: (request: Request) => Promise<Response> }
+) => {
+	await app.handle(
+		new Request('http://localhost/auth/register', {
+			body: JSON.stringify({
+				email: 'l@example.com',
+				password: 'supersecret'
+			}),
+			headers: { 'content-type': 'application/json' },
+			method: 'POST'
+		})
+	);
+
+	return app.handle(
+		new Request('http://localhost/auth/login', {
+			body: JSON.stringify({
+				email: 'l@example.com',
+				password: 'supersecret'
+			}),
+			headers: { 'content-type': 'application/json' },
+			method: 'POST'
+		})
+	);
+};
+
+describe('resolveCookieSecure', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	afterEach(() => {
+		process.env.NODE_ENV = originalNodeEnv;
+	});
+
+	test('explicit override wins over NODE_ENV', () => {
+		process.env.NODE_ENV = 'production';
+		expect(resolveCookieSecure(false)).toBe(false);
+		process.env.NODE_ENV = 'development';
+		expect(resolveCookieSecure(true)).toBe(true);
+	});
+
+	test('defaults to false when NODE_ENV !== production', () => {
+		process.env.NODE_ENV = 'development';
+		expect(resolveCookieSecure()).toBe(false);
+		process.env.NODE_ENV = 'test';
+		expect(resolveCookieSecure()).toBe(false);
+		delete process.env.NODE_ENV;
+		expect(resolveCookieSecure()).toBe(false);
+	});
+
+	test('defaults to true when NODE_ENV === production', () => {
+		process.env.NODE_ENV = 'production';
+		expect(resolveCookieSecure()).toBe(true);
+	});
+});
+
+describe('credential login cookie Secure flag (issue #6)', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	beforeEach(() => {
+		process.env.NODE_ENV = originalNodeEnv;
+	});
+
+	test('omits Secure on a dev login so curl/SSR/test-runners can round-trip', async () => {
+		process.env.NODE_ENV = 'development';
+		const response = await registerAndLogin(buildLoginApp());
+
+		const setCookie = response.headers.get('set-cookie') ?? '';
+		expect(setCookie).toContain('user_session_id');
+		expect(setCookie).not.toContain('Secure');
+		expect(setCookie).toContain('HttpOnly');
+	});
+
+	test('sets Secure on a prod login (NODE_ENV=production default)', async () => {
+		process.env.NODE_ENV = 'production';
+		const response = await registerAndLogin(buildLoginApp());
+
+		const setCookie = response.headers.get('set-cookie') ?? '';
+		expect(setCookie).toContain('user_session_id');
+		expect(setCookie).toContain('Secure');
+	});
+
+	test('honors an explicit `cookieSecure: true` even in dev', async () => {
+		process.env.NODE_ENV = 'development';
+		const response = await registerAndLogin(buildLoginApp(true));
+
+		const setCookie = response.headers.get('set-cookie') ?? '';
+		expect(setCookie).toContain('user_session_id');
+		expect(setCookie).toContain('Secure');
+	});
+
+	test('honors an explicit `cookieSecure: false` even in prod', async () => {
+		process.env.NODE_ENV = 'production';
+		const response = await registerAndLogin(buildLoginApp(false));
+
+		const setCookie = response.headers.get('set-cookie') ?? '';
+		expect(setCookie).toContain('user_session_id');
+		expect(setCookie).not.toContain('Secure');
+	});
+});


### PR DESCRIPTION
Closes #6.

## Why we never hit this
- Every flow we test goes through Playwright (browser UA). Browsers treat `localhost` as a [secure context](https://www.w3.org/TR/secure-contexts/#is-origin-potentially-trustworthy) and DO round-trip `Secure` cookies over plain HTTP to localhost.
- Intent runs full HTTPS in prod via DigitalOcean, so `Secure` is correct there.
- We never `curl` against a dev auth flow. The reporter found it the moment they did.

## Fix
- New `cookieSecure?: boolean` on `AuthConfig`, default `process.env.NODE_ENV === 'production'` (the convention used by express-session, iron-session, lucia, better-auth — option 1 from the issue).
- New `resolveCookieSecure(override?)` helper, exported from the package root for consumer-built routes.
- Threaded through every cookie-setting site: `authorize` (6 OAuth flow cookies), credentials (login + register), mfa challenge, passwordless, webauthn, sso oidc + saml, plus the public helpers `promoteToSession`, `startImpersonation`, `endImpersonation`, `addToSessionRing`, `removeFromSessionRing`, `switchActiveSession`, `createAnonymousSession`, `getUserSessionId`, `instantiateUserSession`.
- `cookieSecure` is **optional** everywhere — passing nothing falls back to the env default, so existing consumer callsites don't need an update.

## Tests
7 new tests in `tests/cookieSecure.test.ts` lock the resolution logic + the dev/prod set-cookie behavior on the credentials login route. **339 / 339 tests pass.** Typecheck + lint clean.

## Version
0.30.0 → 0.31.0 (minor — minor behavior change for the rare prod-without-`NODE_ENV` setup; release notes call that out).

## Migration
If you run prod without setting `NODE_ENV=production`, set `cookieSecure: true` explicitly on your auth config.