### PR TITLE
fix: signout works on any session type, not just OAuth (closes #7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.31.0",
+	"version": "0.32.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/routes/signout.ts
+++ b/src/routes/signout.ts
@@ -42,16 +42,17 @@ export const signout = <UserType>({
 			store: { session },
 			cookie: { user_session_id, auth_provider }
 		}) => {
-			if (auth_provider === undefined || user_session_id === undefined) {
+			if (user_session_id === undefined) {
 				return status('Bad Request', 'Cookies are missing');
-			}
-
-			if (auth_provider.value === undefined) {
-				return status('Unauthorized', 'No auth provider found');
 			}
 			if (user_session_id.value === undefined) {
 				return status('Unauthorized', 'No user session id found');
 			}
+			// `auth_provider` is only set by the OAuth2 `/authorize` flow. Credentials,
+			// MFA, passwordless, SSO, WebAuthn, and impersonation-minted sessions never
+			// set it — but they are still valid sessions and must be signable-out.
+			// Prior versions hard-failed here, which 401'd every non-OAuth signout
+			// (issue #7).
 
 			const compatibilityLayer = await createSessionCompatibilityLayer({
 				authSessionStore,
@@ -64,7 +65,7 @@ export const signout = <UserType>({
 
 			if (currentSession !== undefined) {
 				const signedOut = await runSignOut(onSignOut, {
-					authProvider: auth_provider.value,
+					authProvider: auth_provider?.value,
 					session: signoutSession,
 					userSessionId: user_session_id.value
 				});
@@ -88,7 +89,7 @@ export const signout = <UserType>({
 			}
 
 			user_session_id.remove();
-			auth_provider.remove();
+			auth_provider?.remove();
 
 			return new Response(null, { status: 204 });
 		},

--- a/src/types.ts
+++ b/src/types.ts
@@ -324,7 +324,11 @@ export type OnSignOut<UserType> =
 			userSessionId,
 			session
 	  }: {
-			authProvider: string;
+			/** Set only when the session was minted by the OAuth2 `/authorize` flow —
+			 *  credentials, MFA, passwordless, SSO, WebAuthn, and impersonation-minted
+			 *  sessions sign out without one. Use it to revoke the upstream provider
+			 *  token when present; ignore when undefined. */
+			authProvider: string | undefined;
 			userSessionId: UserSessionId;
 			session: SessionRecord<UserType>;
 	  }) => void | Promise<void>)

--- a/tests/signoutCredentials.test.ts
+++ b/tests/signoutCredentials.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import type { CredentialsConfig } from '../src/credentials/config';
+import { credentialsLogin } from '../src/credentials/login';
+import { credentialsRegister } from '../src/credentials/register';
+import { createInMemoryCredentialStore } from '../src/credentials/inMemoryCredentialStore';
+import { signout } from '../src/routes/signout';
+
+// Repros issue #7: `DELETE /oauth2/signout` 401'd on credentials sessions because the
+// handler hard-failed when the `auth_provider` cookie was missing. But `auth_provider`
+// is only set during the OAuth2 `/authorize` flow — credentials, MFA, passwordless,
+// SSO, WebAuthn, and impersonation-minted sessions never have one. So the only signout
+// route in the package couldn't sign out any non-OAuth session. Fix: drop the hard-fail,
+// widen OnSignOut.authProvider to `string | undefined`, keep clearing both cookies.
+
+type TestUser = { email: string; sub: string };
+
+const buildApp = (
+	onSignOut?: (context: {
+		authProvider: string | undefined;
+		userSessionId: string;
+	}) => void
+) => {
+	const credentialStore = createInMemoryCredentialStore();
+	const users = new Map<string, TestUser>();
+	const config: CredentialsConfig<TestUser> = {
+		credentialStore,
+		passwordPolicy: { minLength: 8 },
+		getUserByEmail: (email) => users.get(email) ?? null,
+		onCreateCredentialUser: ({ email }) => {
+			const user: TestUser = { email, sub: `user:${email}` };
+			users.set(email, user);
+
+			return user;
+		},
+		onSendEmail: () => undefined
+	};
+
+	return new Elysia()
+		.use(credentialsRegister(config))
+		.use(credentialsLogin(config))
+		.use(
+			signout<TestUser>({
+				onSignOut: onSignOut
+					? ({ authProvider, userSessionId }) =>
+							onSignOut({ authProvider, userSessionId })
+					: undefined
+			})
+		);
+};
+
+const postJson = (
+	app: { handle: (request: Request) => Promise<Response> },
+	path: string,
+	body: unknown
+) =>
+	app.handle(
+		new Request(`http://localhost${path}`, {
+			body: JSON.stringify(body),
+			headers: { 'content-type': 'application/json' },
+			method: 'POST'
+		})
+	);
+
+const sessionCookieFrom = (response: Response) => {
+	const setCookie = response.headers.get('set-cookie') ?? '';
+	const match = setCookie.match(/user_session_id=([^;]+)/);
+	if (match === null || match[1] === undefined) {
+		throw new Error('no user_session_id in set-cookie');
+	}
+
+	return `user_session_id=${match[1]}`;
+};
+
+describe('credentials signout (issue #7)', () => {
+	test('signs out a credentials session even without auth_provider cookie', async () => {
+		const app = buildApp();
+		await postJson(app, '/auth/register', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		const loginResponse = await postJson(app, '/auth/login', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		expect(loginResponse.status).toBe(200);
+
+		const cookie = sessionCookieFrom(loginResponse);
+		const signoutResponse = await app.handle(
+			new Request('http://localhost/oauth2/signout', {
+				headers: { cookie },
+				method: 'DELETE'
+			})
+		);
+
+		// Pre-fix: 401 "No auth provider found". Post-fix: 204 No Content.
+		expect(signoutResponse.status).toBe(204);
+		const clearedCookie = signoutResponse.headers.get('set-cookie') ?? '';
+		expect(clearedCookie).toContain('user_session_id');
+	});
+
+	test('passes authProvider: undefined to onSignOut for credentials sessions', async () => {
+		const seen: Array<{
+			authProvider: string | undefined;
+			userSessionId: string;
+		}> = [];
+		const app = buildApp((context) => seen.push(context));
+
+		await postJson(app, '/auth/register', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		const loginResponse = await postJson(app, '/auth/login', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		const cookie = sessionCookieFrom(loginResponse);
+
+		await app.handle(
+			new Request('http://localhost/oauth2/signout', {
+				headers: { cookie },
+				method: 'DELETE'
+			})
+		);
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.authProvider).toBeUndefined();
+		expect(seen[0]?.userSessionId).toBeDefined();
+	});
+
+	test('still rejects requests with no session cookie at all', async () => {
+		const app = buildApp();
+		const response = await app.handle(
+			new Request('http://localhost/oauth2/signout', { method: 'DELETE' })
+		);
+		expect(response.status).toBe(401);
+	});
+
+	test('still passes through authProvider when the cookie IS set (OAuth flow)', async () => {
+		const seen: Array<{
+			authProvider: string | undefined;
+			userSessionId: string;
+		}> = [];
+		const app = buildApp((context) => seen.push(context));
+
+		await postJson(app, '/auth/register', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		const loginResponse = await postJson(app, '/auth/login', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		const sessionCookie = sessionCookieFrom(loginResponse);
+		// Simulate the OAuth2 /authorize flow having set auth_provider:
+		const compositeCookie = `${sessionCookie}; auth_provider=github`;
+
+		await app.handle(
+			new Request('http://localhost/oauth2/signout', {
+				headers: { cookie: compositeCookie },
+				method: 'DELETE'
+			})
+		);
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.authProvider).toBe('github');
+	});
+});


### PR DESCRIPTION
Closes #7.

## Why we never hit this
- Intent built its own `/users/signout` (and `/coaches/signout`, `/admins/signout`) that calls `authSessionStore.removeSession()` + clears the cookie directly, bypassing the package route.
- Every other credentials-using consumer probably did the same the moment they hit the 401.

## Root cause
`auth_provider` is only set during the OAuth2 `/authorize` flow. Credentials, MFA, passwordless, SSO, WebAuthn, and impersonation-minted sessions never have one — but the signout handler hard-failed when it was missing. So the only signout route in the package couldn't sign out any non-OAuth session.

## Fix
- Drop the `auth_provider.value === undefined` hard-fail. A valid `user_session_id` is now sufficient.
- Widen `OnSignOut` context: `authProvider: string` → `authProvider: string | undefined`. Consumers can still revoke the upstream provider token when present; ignore when undefined.
- `composeSignOutAudit` records `metadata.authProvider` either way (undefined drops to `{}` on JSON serialize).

## Tests
4 new tests in `tests/signoutCredentials.test.ts`:
- Credentials signout returns 204 (was 401 pre-fix).
- `onSignOut` receives `authProvider: undefined` for credentials sessions.
- No-cookie request still 401s.
- OAuth-flow signout still passes `authProvider` through to `onSignOut`.

**343 / 343 tests pass.** Typecheck + lint clean.

## Version
0.31.0 → 0.32.0 (minor — `OnSignOut` type widened).

## Migration
Consumers who explicitly typed the OnSignOut parameter as `authProvider: string` need to update to `string | undefined` (or let TS infer). No runtime breakage for OAuth-only consumers.