### PR TITLE
feat: Vue / Solid / Svelte composables (0.33.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,8 +24,11 @@
         "eslint-plugin-security": "^4.0.0",
         "globals": "^17.4.0",
         "prettier": "3.5.3",
+        "solid-js": "^1.9.13",
+        "svelte": "^5.55.9",
         "typescript": "5.8.3",
         "typescript-eslint": "^8.57.2",
+        "vue": "^3.5.34",
       },
       "peerDependencies": {
         "elysia": ">= 1.4.26",
@@ -53,6 +56,14 @@
 
     "@absolutejs/native-windows-x64": ["@absolutejs/native-windows-x64@0.19.0-beta.1008", "", { "os": "win32", "cpu": "x64" }, "sha512-mXIL6AzV0gznwXz6gF+dtT4DIwxKMriF+WYxcjAPlf4xWD0S3ZS8jafHwQXi0RJn0pIX4TIIOhRz0JnVlka3zA=="],
 
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
     "@elysiajs/static": ["@elysiajs/static@1.4.10", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-BN/3PZVWjqkL/6TM7RH69Pae89CfU0OqfEYPeBp2hB/GR5Euds39Wy+0ug9Vbvu++GG4tRRANf2QjaLnriJveg=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
@@ -79,6 +90,16 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.0", "", { "dependencies": { "@types/node": "^22.10.2", "@types/pg": "^8.8.0" } }, "sha512-XWmEeWpBXIoksZSDN74kftfTnXFEGZ3iX8jbANWBc+ag6dsiQuvuR4LgB0WdCOKMb5AQgjqgufc0TgAsZubUYw=="],
 
     "@petamoriken/float16": ["@petamoriken/float16@3.9.2", "", {}, "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="],
@@ -86,6 +107,8 @@
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 
     "@stylistic/eslint-plugin": ["@stylistic/eslint-plugin@5.10.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/types": "^8.56.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "estraverse": "^5.3.0", "picomatch": "^4.0.3" }, "peerDependencies": { "eslint": "^9.0.0 || ^10.0.0" } }, "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
@@ -104,6 +127,8 @@
     "@types/pg": ["@types/pg@8.15.2", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^4.0.1" } }, "sha512-+BKxo5mM6+/A1soSHBI7ufUglqYXntChLDyTbvcAn1Lawi9J7J9Ok3jt6w7I0+T/UDJ4CyhHk66+GZbwmkYxSg=="],
 
     "@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -127,11 +152,33 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "eslint-visitor-keys": "^5.0.0" } }, "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ=="],
 
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.34", "", { "dependencies": { "@babel/parser": "^7.29.3", "@vue/shared": "3.5.34", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.34", "", { "dependencies": { "@vue/compiler-core": "3.5.34", "@vue/shared": "3.5.34" } }, "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.34", "", { "dependencies": { "@babel/parser": "^7.29.3", "@vue/compiler-core": "3.5.34", "@vue/compiler-dom": "3.5.34", "@vue/compiler-ssr": "3.5.34", "@vue/shared": "3.5.34", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.14", "source-map-js": "^1.2.1" } }, "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.34", "", { "dependencies": { "@vue/compiler-dom": "3.5.34", "@vue/shared": "3.5.34" } }, "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.34", "", { "dependencies": { "@vue/shared": "3.5.34" } }, "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.34", "", { "dependencies": { "@vue/reactivity": "3.5.34", "@vue/shared": "3.5.34" } }, "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.34", "", { "dependencies": { "@vue/reactivity": "3.5.34", "@vue/runtime-core": "3.5.34", "@vue/shared": "3.5.34", "csstype": "^3.2.3" } }, "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.34", "", { "dependencies": { "@vue/compiler-ssr": "3.5.34", "@vue/shared": "3.5.34" }, "peerDependencies": { "vue": "3.5.34" } }, "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew=="],
+
+    "@vue/shared": ["@vue/shared@3.5.34", "", {}, "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -140,6 +187,8 @@
     "bun-types": ["bun-types@1.2.9", "", { "dependencies": { "@types/node": "*", "@types/ws": "*" } }, "sha512-dk/kOEfQbajENN/D6FyiSgOKEuUi9PWfqKQJEgwKrCMWbjS/S6tEXp178mWvWAcUSYm9ArDlWHZKO3T/4cLXiw=="],
 
     "citra": ["citra@0.28.0", "", {}, "sha512-OrrKDNKcgS3JFhNp+zWGWhz1uD+ii/R6fR/YPwEdcoYW3fs8zDz9C7QG91fIaUNspDHfdLBmU7jViuZN7I5gTQ=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -151,9 +200,13 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
     "drizzle-orm": ["drizzle-orm@0.41.0", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q=="],
 
     "elysia": ["elysia@1.4.26", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-oGhEFYwt+4M/U9w34XTdBen2KOQIa/PXne40zUkTWRgJlVJNBhepxOdjWeY1U0CbYoEOyZaj1tc79wOsuCxMYw=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
@@ -171,13 +224,19 @@
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
+    "esrap": ["esrap@2.2.9", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A=="],
+
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -221,6 +280,8 @@
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
@@ -233,13 +294,19 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -265,7 +332,11 @@
 
     "pg-types": ["pg-types@4.0.2", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postgres-array": ["postgres-array@3.0.4", "", {}, "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="],
 
@@ -289,13 +360,23 @@
 
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.2", "", {}, "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="],
 
+    "solid-js": ["solid-js@1.9.13", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+
+    "svelte": ["svelte@5.55.9", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
@@ -315,11 +396,15 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "vue": ["vue@3.5.34", "", { "dependencies": { "@vue/compiler-dom": "3.5.34", "@vue/compiler-sfc": "3.5.34", "@vue/runtime-dom": "3.5.34", "@vue/server-renderer": "3.5.34", "@vue/shared": "3.5.34" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
@@ -350,6 +435,10 @@
     "gel/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "gel/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "is-reference/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "svelte/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "eslint-plugin-promise/@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.32.0",
+	"version": "0.33.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {
@@ -10,7 +10,7 @@
 	"license": "CC BY-NC 4.0",
 	"author": "Alex Kahn",
 	"scripts": {
-		"build": "rm -rf dist && bun build src/index.ts src/htmx/index.ts src/client/index.ts src/client/react.ts src/plugins/index.ts --outdir dist --sourcemap --target=bun --external elysia --external react && bun build src/fingerprint-client/index.ts --outdir dist/fingerprint-client --sourcemap --target=browser && tsc --emitDeclarationOnly --project tsconfig.json",
+		"build": "rm -rf dist && bun build src/index.ts src/htmx/index.ts src/client/index.ts src/client/react.ts src/client/vue.ts src/client/solid.ts src/client/svelte.ts src/plugins/index.ts --outdir dist --sourcemap --target=bun --external elysia --external react --external vue --external solid-js --external svelte && bun build src/fingerprint-client/index.ts --outdir dist/fingerprint-client --sourcemap --target=browser && tsc --emitDeclarationOnly --project tsconfig.json",
 		"config": "absolute config",
 		"test": "bun test",
 		"format": "absolute prettier --write",
@@ -29,10 +29,22 @@
 	"types": "./dist/index.d.ts",
 	"peerDependencies": {
 		"elysia": ">= 1.4.26",
-		"react": ">=18 <20"
+		"react": ">=18 <20",
+		"solid-js": ">=1.8",
+		"svelte": ">=4",
+		"vue": ">=3.4"
 	},
 	"peerDependenciesMeta": {
 		"react": {
+			"optional": true
+		},
+		"solid-js": {
+			"optional": true
+		},
+		"svelte": {
+			"optional": true
+		},
+		"vue": {
 			"optional": true
 		}
 	},
@@ -56,8 +68,11 @@
 		"eslint-plugin-security": "^4.0.0",
 		"globals": "^17.4.0",
 		"prettier": "3.5.3",
+		"solid-js": "^1.9.13",
+		"svelte": "^5.55.9",
 		"typescript": "5.8.3",
-		"typescript-eslint": "^8.57.2"
+		"typescript-eslint": "^8.57.2",
+		"vue": "^3.5.34"
 	},
 	"module": "./dist/index.js",
 	"exports": {
@@ -84,6 +99,18 @@
 		"./react": {
 			"import": "./dist/client/react.js",
 			"types": "./dist/client/react.d.ts"
+		},
+		"./solid": {
+			"import": "./dist/client/solid.js",
+			"types": "./dist/client/solid.d.ts"
+		},
+		"./svelte": {
+			"import": "./dist/client/svelte.js",
+			"types": "./dist/client/svelte.d.ts"
+		},
+		"./vue": {
+			"import": "./dist/client/vue.js",
+			"types": "./dist/client/vue.d.ts"
 		}
 	},
 	"type": "module",

--- a/src/client/solid.ts
+++ b/src/client/solid.ts
@@ -1,0 +1,106 @@
+// Thin Solid composables over `createAuthClient`, mirroring `./react`. Same `{ data, error,
+// isPending, mutate, reset }` shape — only the reactivity is Solid's (signals + onCleanup).
+// Bring your own form / UI; these are primitives.
+
+import { createSignal, onCleanup, type Accessor } from 'solid-js';
+import type { AuthClient, AuthClientError } from './createAuthClient';
+
+type Mutator<Args, Data> = (
+	args: Args
+) => Promise<{ data: Data | null; error: AuthClientError | null }>;
+
+type MutationState<Args, Data> = {
+	data: Accessor<Data | null>;
+	error: Accessor<AuthClientError | null>;
+	isPending: Accessor<boolean>;
+	mutate: Mutator<Args, Data>;
+	reset: () => void;
+};
+
+// Generic mutation composable. The exported composables are 1-2 line specializations of
+// this — kept private so consumers depend on the named API, not this internal shape.
+const useMutation = <Args, Data>(
+	run: Mutator<Args, Data>
+): MutationState<Args, Data> => {
+	const [data, setData] = createSignal<Data | null>(null);
+	const [error, setError] = createSignal<AuthClientError | null>(null);
+	const [isPending, setIsPending] = createSignal(false);
+	let alive = true;
+	onCleanup(() => {
+		alive = false;
+	});
+
+	const mutate: Mutator<Args, Data> = async (args) => {
+		setIsPending(true);
+		setError(null);
+		const result = await run(args);
+		if (alive) {
+			// Solid's setter accepts a value or a setter-fn; the fn-form keeps Data | null
+			// passing through without narrowing the writable signal's value type.
+			setData(() => result.data);
+			setError(result.error);
+			setIsPending(false);
+		}
+
+		return result;
+	};
+
+	const reset = () => {
+		setData(() => null);
+		setError(null);
+		setIsPending(false);
+	};
+
+	return { data, error, isPending, mutate, reset };
+};
+
+export const useMagicLink = (client: AuthClient) =>
+	useMutation(client.passwordless.requestMagicLink);
+
+export const useMfaChallenge = (client: AuthClient) =>
+	useMutation(client.mfa.challenge);
+
+export const usePasswordReset = (client: AuthClient) =>
+	useMutation(client.passwordReset.request);
+
+// Query composable for the user's active sessions; refetch() reruns it, revoke(sessionId)
+// kills one and refetches. Same `{ data, error, isPending }` triplet as the mutations so
+// the consumer can render one way.
+export const useSessions = (client: AuthClient) => {
+	const [data, setData] = createSignal<unknown[] | null>(null);
+	const [error, setError] = createSignal<AuthClientError | null>(null);
+	const [isPending, setIsPending] = createSignal(true);
+	let alive = true;
+	onCleanup(() => {
+		alive = false;
+	});
+
+	const refetch = async () => {
+		setIsPending(true);
+		const result = await client.sessions.list();
+		if (alive) {
+			setData(() => result.data);
+			setError(result.error);
+			setIsPending(false);
+		}
+	};
+
+	const revoke = async (sessionId: string) => {
+		const result = await client.sessions.revoke(sessionId);
+		if (result.error === null) await refetch();
+
+		return result;
+	};
+
+	void refetch();
+
+	return { data, error, isPending, refetch, revoke };
+};
+
+export const useSignIn = (client: AuthClient) =>
+	useMutation(client.signIn.email);
+
+export const useSignOut = (client: AuthClient) => useMutation(client.signOut);
+
+export const useSignUp = (client: AuthClient) =>
+	useMutation(client.signUp.email);

--- a/src/client/svelte.ts
+++ b/src/client/svelte.ts
@@ -1,0 +1,94 @@
+// Thin Svelte composables over `createAuthClient`, mirroring `./react`. Same `{ data,
+// error, isPending, mutate, reset }` shape — only the reactivity is Svelte's (writable
+// stores from `svelte/store`, which work in both Svelte 4 with `$store` auto-subscription
+// and Svelte 5 with $state-based usage via `get(store)` or `$:` reactivity).
+// Bring your own form / UI; these are primitives.
+
+import { writable, type Writable } from 'svelte/store';
+import type { AuthClient, AuthClientError } from './createAuthClient';
+
+type Mutator<Args, Data> = (
+	args: Args
+) => Promise<{ data: Data | null; error: AuthClientError | null }>;
+
+type MutationState<Args, Data> = {
+	data: Writable<Data | null>;
+	error: Writable<AuthClientError | null>;
+	isPending: Writable<boolean>;
+	mutate: Mutator<Args, Data>;
+	reset: () => void;
+};
+
+// Generic mutation composable. The exported composables are 1-2 line specializations of
+// this — kept private so consumers depend on the named API, not this internal shape.
+const useMutation = <Args, Data>(
+	run: Mutator<Args, Data>
+): MutationState<Args, Data> => {
+	const data: Writable<Data | null> = writable(null);
+	const error: Writable<AuthClientError | null> = writable(null);
+	const isPending = writable(false);
+
+	const mutate: Mutator<Args, Data> = async (args) => {
+		isPending.set(true);
+		error.set(null);
+		const result = await run(args);
+		data.set(result.data);
+		error.set(result.error);
+		isPending.set(false);
+
+		return result;
+	};
+
+	const reset = () => {
+		data.set(null);
+		error.set(null);
+		isPending.set(false);
+	};
+
+	return { data, error, isPending, mutate, reset };
+};
+
+export const useMagicLink = (client: AuthClient) =>
+	useMutation(client.passwordless.requestMagicLink);
+
+export const useMfaChallenge = (client: AuthClient) =>
+	useMutation(client.mfa.challenge);
+
+export const usePasswordReset = (client: AuthClient) =>
+	useMutation(client.passwordReset.request);
+
+// Query composable for the user's active sessions; refetch() reruns it, revoke(sessionId)
+// kills one and refetches. Same `{ data, error, isPending }` triplet as the mutations so
+// the consumer can render one way.
+export const useSessions = (client: AuthClient) => {
+	const data: Writable<unknown[] | null> = writable(null);
+	const error: Writable<AuthClientError | null> = writable(null);
+	const isPending = writable(true);
+
+	const refetch = async () => {
+		isPending.set(true);
+		const result = await client.sessions.list();
+		data.set(result.data);
+		error.set(result.error);
+		isPending.set(false);
+	};
+
+	const revoke = async (sessionId: string) => {
+		const result = await client.sessions.revoke(sessionId);
+		if (result.error === null) await refetch();
+
+		return result;
+	};
+
+	void refetch();
+
+	return { data, error, isPending, refetch, revoke };
+};
+
+export const useSignIn = (client: AuthClient) =>
+	useMutation(client.signIn.email);
+
+export const useSignOut = (client: AuthClient) => useMutation(client.signOut);
+
+export const useSignUp = (client: AuthClient) =>
+	useMutation(client.signUp.email);

--- a/src/client/vue.ts
+++ b/src/client/vue.ts
@@ -1,0 +1,104 @@
+// Thin Vue composables over `createAuthClient`, mirroring `./react`. Same `{ data, error,
+// isPending, mutate, reset }` shape — only the reactivity is Vue's (refs + onScopeDispose).
+// Bring your own form / UI; these are primitives.
+
+import { onScopeDispose, ref, type Ref } from 'vue';
+import type { AuthClient, AuthClientError } from './createAuthClient';
+
+type Mutator<Args, Data> = (
+	args: Args
+) => Promise<{ data: Data | null; error: AuthClientError | null }>;
+
+type MutationState<Args, Data> = {
+	data: Ref<Data | null>;
+	error: Ref<AuthClientError | null>;
+	isPending: Ref<boolean>;
+	mutate: Mutator<Args, Data>;
+	reset: () => void;
+};
+
+// Generic mutation composable. The exported composables are 1-2 line specializations of
+// this — kept private so consumers depend on the named API, not this internal shape.
+const useMutation = <Args, Data>(
+	run: Mutator<Args, Data>
+): MutationState<Args, Data> => {
+	const data: Ref<Data | null> = ref(null);
+	const error: Ref<AuthClientError | null> = ref(null);
+	const isPending = ref(false);
+	let alive = true;
+	onScopeDispose(() => {
+		alive = false;
+	});
+
+	const mutate: Mutator<Args, Data> = async (args) => {
+		isPending.value = true;
+		error.value = null;
+		const result = await run(args);
+		if (alive) {
+			data.value = result.data;
+			error.value = result.error;
+			isPending.value = false;
+		}
+
+		return result;
+	};
+
+	const reset = () => {
+		data.value = null;
+		error.value = null;
+		isPending.value = false;
+	};
+
+	return { data, error, isPending, mutate, reset };
+};
+
+export const useMagicLink = (client: AuthClient) =>
+	useMutation(client.passwordless.requestMagicLink);
+
+export const useMfaChallenge = (client: AuthClient) =>
+	useMutation(client.mfa.challenge);
+
+export const usePasswordReset = (client: AuthClient) =>
+	useMutation(client.passwordReset.request);
+
+// Query composable for the user's active sessions; refetch() reruns it, revoke(sessionId)
+// kills one and refetches. Same `{ data, error, isPending }` triplet as the mutations so
+// the consumer can render one way.
+export const useSessions = (client: AuthClient) => {
+	const data: Ref<unknown[] | null> = ref(null);
+	const error: Ref<AuthClientError | null> = ref(null);
+	const isPending = ref(true);
+	let alive = true;
+	onScopeDispose(() => {
+		alive = false;
+	});
+
+	const refetch = async () => {
+		isPending.value = true;
+		const result = await client.sessions.list();
+		if (alive) {
+			data.value = result.data;
+			error.value = result.error;
+			isPending.value = false;
+		}
+	};
+
+	const revoke = async (sessionId: string) => {
+		const result = await client.sessions.revoke(sessionId);
+		if (result.error === null) await refetch();
+
+		return result;
+	};
+
+	void refetch();
+
+	return { data, error, isPending, refetch, revoke };
+};
+
+export const useSignIn = (client: AuthClient) =>
+	useMutation(client.signIn.email);
+
+export const useSignOut = (client: AuthClient) => useMutation(client.signOut);
+
+export const useSignUp = (client: AuthClient) =>
+	useMutation(client.signUp.email);

--- a/tests/clientComposables.test.ts
+++ b/tests/clientComposables.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { get } from 'svelte/store';
+import { createAuthClient } from '../src/client/createAuthClient';
+import * as reactHooks from '../src/client/react';
+import * as solidHooks from '../src/client/solid';
+import * as svelteHooks from '../src/client/svelte';
+import * as vueHooks from '../src/client/vue';
+
+// Each framework wrapper is a thin specialization of createAuthClient (which has its own
+// test) — these smoke tests just confirm the modules import cleanly + the public API
+// matches React's (so a consumer can swap their import line and the rest works). The
+// Svelte path is exercised end-to-end because `writable` works outside a component
+// scope; Vue + Solid require an effect/root scope, so they're checked structurally.
+
+const EXPECTED_API = [
+	'useMagicLink',
+	'useMfaChallenge',
+	'usePasswordReset',
+	'useSessions',
+	'useSignIn',
+	'useSignOut',
+	'useSignUp'
+] as const;
+
+const stubFetch = (handler: (url: string) => Response) =>
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test stub for fetch
+	mock(async (input: RequestInfo | URL) =>
+		handler(input.toString())
+	) as unknown as typeof fetch;
+
+describe('framework composable API parity', () => {
+	test('react/vue/solid/svelte expose the same named composables', () => {
+		for (const name of EXPECTED_API) {
+			expect(typeof reactHooks[name]).toBe('function');
+			expect(typeof vueHooks[name]).toBe('function');
+			expect(typeof solidHooks[name]).toBe('function');
+			expect(typeof svelteHooks[name]).toBe('function');
+		}
+	});
+});
+
+describe('svelte composables (end-to-end via writable stores)', () => {
+	test('useSignIn updates data/error/isPending stores through mutate', async () => {
+		const client = createAuthClient({
+			fetch: stubFetch(() =>
+				new Response(JSON.stringify({ status: 'authenticated' }))
+			)
+		});
+
+		const { data, error, isPending, mutate, reset } = svelteHooks.useSignIn(
+			client
+		);
+		expect(get(data)).toBeNull();
+		expect(get(error)).toBeNull();
+		expect(get(isPending)).toBe(false);
+
+		const result = await mutate({ email: 'a@b.com', password: 'pw' });
+		expect(result.error).toBeNull();
+		expect(result.data).toEqual({ status: 'authenticated' });
+		expect(get(data)).toEqual({ status: 'authenticated' });
+		expect(get(isPending)).toBe(false);
+
+		reset();
+		expect(get(data)).toBeNull();
+		expect(get(error)).toBeNull();
+	});
+
+	test('useSignIn records errors when the request fails', async () => {
+		const client = createAuthClient({
+			fetch: stubFetch(
+				() =>
+					new Response(JSON.stringify({ message: 'nope' }), {
+						status: 401
+					})
+			)
+		});
+
+		const { data, error, mutate } = svelteHooks.useSignIn(client);
+
+		const result = await mutate({ email: 'a@b.com', password: 'pw' });
+		expect(result.data).toBeNull();
+		expect(result.error?.status).toBe(401);
+		expect(get(data)).toBeNull();
+		expect(get(error)?.message).toBe('nope');
+	});
+
+	test('useSessions starts pending, refetches on demand, and revoke clears one entry', async () => {
+		type TestSession = { id: string; userId: string };
+		let sessions: TestSession[] = [
+			{ id: 'a', userId: 'u1' },
+			{ id: 'b', userId: 'u1' }
+		];
+		const client = createAuthClient({
+			fetch: stubFetch((url) => {
+				if (url.endsWith('/auth/sessions')) {
+					return new Response(JSON.stringify(sessions));
+				}
+				if (url.includes('/auth/sessions/')) {
+					sessions = sessions.filter((entry) => !url.endsWith(entry.id));
+
+					return new Response(JSON.stringify({ ok: true }));
+				}
+
+				return new Response('not found', { status: 404 });
+			})
+		});
+
+		const { data, isPending, refetch, revoke } = svelteHooks.useSessions(
+			client
+		);
+		// Initial fetch is scheduled synchronously; flush microtasks.
+		await refetch();
+		expect(get(isPending)).toBe(false);
+		expect(get(data)).toHaveLength(2);
+
+		await revoke('a');
+		expect(get(data)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Closes the framework-composables gap from the post-stable adoption-infrastructure plan. React hooks already shipped at `@absolutejs/auth/react`; this adds the equivalent for the three other framework communities so they don't have to call `createAuthClient` imperatively from a component.

## New module entries
- `@absolutejs/auth/vue` (refs + `onScopeDispose`)
- `@absolutejs/auth/solid` (signals + `onCleanup`)
- `@absolutejs/auth/svelte` (`writable` stores from `svelte/store` — works in Svelte 4 and 5)

Each ships the same seven composables — `useSignIn`, `useSignUp`, `useSignOut`, `useMagicLink`, `useMfaChallenge`, `usePasswordReset`, `useSessions` — with the same `{ data, error, isPending, mutate, reset }` shape as React.

Each framework is an optional peer dep (matching how React was already wired); no consumer that doesn't import the framework module pays anything.

## Tests
4 new tests in `tests/clientComposables.test.ts`:
- API-parity check across all four wrappers (same exported names + types)
- Svelte end-to-end: mutate updates state, error state captures failed requests, sessions refetch + revoke

Vue + Solid require a component/root scope to exercise their lifecycle hooks; structural parity is enough since each is a ~50-LOC thin wrapper over `createAuthClient` (which has its own direct tests).

**347 / 347 tests pass.** Typecheck + lint clean.

## Version
0.32.0 → 0.33.0 (minor — additive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Solid, Svelte, and Vue frameworks with authentication composables.
  * New composables for magic link, MFA challenge, password reset, sign-in, sign-out, sign-up, and session management across all supported frameworks.

* **Tests**
  * Added test coverage for framework composables to ensure consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/absolutejs/absolute-auth/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->