### PR TITLE
feat: Redis-backed FgaCache for multi-instance sharing (0.34.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/fga/config.ts
+++ b/src/fga/config.ts
@@ -7,10 +7,14 @@ const DEFAULT_CACHE_MAX_ENTRIES = 10000;
 // Optional memoization for `check`. Bounds reads at the cost of TTL-bounded staleness; writes
 // through `writeWarrant`/`deleteWarrant` clear it on the writing instance (other instances see
 // staleness up to ttlMs). Supply your own (e.g. Redis-backed) or use createInMemoryCheckCache.
+//
+// `get` may be sync or async so a network-backed cache (Redis) can implement the contract;
+// `set` and `clear` are fire-and-forget for the in-memory path and may return promises that
+// are intentionally not awaited for the Redis path (cache is a hint, not a source of truth).
 export type FgaCache = {
-	clear: () => void;
-	get: (key: string) => boolean | undefined;
-	set: (key: string, value: boolean) => void;
+	clear: () => void | Promise<void>;
+	get: (key: string) => boolean | undefined | Promise<boolean | undefined>;
+	set: (key: string, value: boolean) => void | Promise<void>;
 };
 
 export type FgaConfig = {
@@ -176,7 +180,7 @@ const cacheKey = (query: CheckQuery) =>
 // inheritance rules)? Memoized when `config.cache` is set.
 export const check = async (config: FgaConfig, query: CheckQuery) => {
 	const key = cacheKey(query);
-	const cached = config.cache?.get(key);
+	const cached = await config.cache?.get(key);
 	if (cached !== undefined) return cached;
 
 	const context: EvalContext = {

--- a/src/fga/redisCheckCache.ts
+++ b/src/fga/redisCheckCache.ts
@@ -1,0 +1,49 @@
+import type { RedisLike } from '../stores/redis';
+import type { FgaCache } from './config';
+
+const DEFAULT_TTL_MS = 5000;
+const DEFAULT_PREFIX = 'auth:fga:';
+
+// Redis-backed `check` cache for multi-instance setups, mirroring createInMemoryCheckCache.
+// Every instance shares the same Redis keyspace, so a check that hits cache on instance A
+// also hits on instance B. TTL bounds staleness identically across instances.
+//
+// `clear()` semantics: the FGA pipeline clears the cache on every `writeWarrant` /
+// `deleteWarrant` so a permission change takes effect immediately on the writing instance.
+// RedisLike doesn't expose key enumeration, so without an additional `keys(pattern)`
+// method, `clear()` is a no-op + the docstring notes other instances see staleness up to
+// `ttlMs`. If your client (ioredis, node-redis, @upstash/redis, Bun's RedisClient) exposes
+// `keys`, pass it as `RedisFgaCacheClient` and `clear()` will scan-and-delete the prefixed
+// namespace. At very large scale, back the `keys` implementation with SCAN instead of KEYS
+// to avoid blocking Redis.
+export type RedisFgaCacheClient = RedisLike & {
+	keys?: (pattern: string) => Promise<string[]>;
+};
+
+type CreateRedisFgaCacheOptions = {
+	keyPrefix?: string;
+	ttlMs?: number;
+};
+
+const parseBoolean = (raw: string | null) => {
+	if (raw === 'true') return true;
+	if (raw === 'false') return false;
+
+	return undefined;
+};
+
+export const createRedisFgaCache = (
+	redis: RedisFgaCacheClient,
+	{ keyPrefix = DEFAULT_PREFIX, ttlMs = DEFAULT_TTL_MS }: CreateRedisFgaCacheOptions = {}
+): FgaCache => ({
+	clear: async () => {
+		const enumerate = redis.keys;
+		if (enumerate === undefined) return;
+		const keys = await enumerate(`${keyPrefix}*`);
+		await Promise.all(keys.map((key) => redis.del(key)));
+	},
+	get: async (key) => parseBoolean(await redis.get(keyPrefix + key)),
+	set: async (key, value) => {
+		await redis.set(keyPrefix + key, value ? 'true' : 'false', ttlMs);
+	}
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -695,6 +695,10 @@ export * from './fga/schema';
 export * from './fga/types';
 export { createInMemoryWarrantStore, warrantKey } from './fga/inMemoryStores';
 export {
+	createRedisFgaCache,
+	type RedisFgaCacheClient
+} from './fga/redisCheckCache';
+export {
 	createNeonWarrantStore,
 	createPostgresWarrantStore,
 	warrantsTable

--- a/tests/fgaRedisCache.test.ts
+++ b/tests/fgaRedisCache.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { check, type FgaConfig, writeWarrant } from '../src/fga/config';
+import { createInMemoryWarrantStore } from '../src/fga/inMemoryStores';
+import {
+	createRedisFgaCache,
+	type RedisFgaCacheClient
+} from '../src/fga/redisCheckCache';
+import type { FgaSchema } from '../src/fga/types';
+
+// Repros the multi-instance use case: two FGA configs both back the same Redis-shared
+// cache. Reads on the second instance must hit the cache that the first instance warmed,
+// and `writeWarrant`-triggered `clear()` must invalidate across both.
+
+const schema: FgaSchema = {
+	document: { viewer: { kind: 'self' } }
+};
+
+type StoreEntry = { expiresAt: number; value: string };
+
+// Minimal in-memory RedisLike + optional keys() shim so tests don't need a real Redis.
+const createFakeRedis = (): RedisFgaCacheClient & {
+	store: Map<string, StoreEntry>;
+} => {
+	const store = new Map<string, StoreEntry>();
+	const prune = (key: string) => {
+		const entry = store.get(key);
+		if (entry !== undefined && entry.expiresAt < Date.now()) store.delete(key);
+	};
+
+	return {
+		store,
+		del: async (key) => {
+			store.delete(key);
+		},
+		get: async (key) => {
+			prune(key);
+
+			return store.get(key)?.value ?? null;
+		},
+		keys: async (pattern) => {
+			const prefix = pattern.replace(/\*$/u, '');
+
+			return Array.from(store.keys()).filter((key) =>
+				key.startsWith(prefix)
+			);
+		},
+		set: async (key, value, ttlMs) => {
+			store.set(key, { expiresAt: Date.now() + ttlMs, value });
+		}
+	};
+};
+
+describe('createRedisFgaCache', () => {
+	let redis: ReturnType<typeof createFakeRedis>;
+	let cache: ReturnType<typeof createRedisFgaCache>;
+	let warrantStore: ReturnType<typeof createInMemoryWarrantStore>;
+	let config: FgaConfig;
+
+	beforeEach(() => {
+		redis = createFakeRedis();
+		cache = createRedisFgaCache(redis, { ttlMs: 60_000 });
+		warrantStore = createInMemoryWarrantStore();
+		config = { cache, schema, warrantStore };
+	});
+
+	test('check warms the Redis cache and a second instance hits it', async () => {
+		await writeWarrant(config, {
+			relation: 'viewer',
+			resourceId: 'doc1',
+			resourceType: 'document',
+			subjectId: 'alice',
+			subjectType: 'user'
+		});
+
+		const first = await check(config, {
+			relation: 'viewer',
+			resourceId: 'doc1',
+			resourceType: 'document',
+			subjectId: 'alice',
+			subjectType: 'user'
+		});
+		expect(first).toBe(true);
+		// Warmed.
+		expect(redis.store.size).toBe(1);
+
+		// Simulate a second instance: new config, same Redis (so same shared cache),
+		// EMPTY warrant store. If the cache hit works across instances, the check
+		// returns true even though the local warrant store knows nothing.
+		const otherStore = createInMemoryWarrantStore();
+		const otherConfig: FgaConfig = {
+			cache: createRedisFgaCache(redis, { ttlMs: 60_000 }),
+			schema,
+			warrantStore: otherStore
+		};
+		const hit = await check(otherConfig, {
+			relation: 'viewer',
+			resourceId: 'doc1',
+			resourceType: 'document',
+			subjectId: 'alice',
+			subjectType: 'user'
+		});
+		expect(hit).toBe(true);
+	});
+
+	test('writeWarrant clears the cache so the next check re-evaluates', async () => {
+		await check(config, {
+			relation: 'viewer',
+			resourceId: 'doc2',
+			resourceType: 'document',
+			subjectId: 'bob',
+			subjectType: 'user'
+		});
+		// Negative result is also cached.
+		expect(redis.store.size).toBe(1);
+
+		await writeWarrant(config, {
+			relation: 'viewer',
+			resourceId: 'doc2',
+			resourceType: 'document',
+			subjectId: 'bob',
+			subjectType: 'user'
+		});
+		// Cache should have been scanned + cleared.
+		expect(redis.store.size).toBe(0);
+
+		const after = await check(config, {
+			relation: 'viewer',
+			resourceId: 'doc2',
+			resourceType: 'document',
+			subjectId: 'bob',
+			subjectType: 'user'
+		});
+		expect(after).toBe(true);
+	});
+
+	test('TTL expiry forces a real check', async () => {
+		const tinyTtlCache = createRedisFgaCache(redis, { ttlMs: 1 });
+		const tinyConfig: FgaConfig = {
+			cache: tinyTtlCache,
+			schema,
+			warrantStore
+		};
+
+		await writeWarrant(tinyConfig, {
+			relation: 'viewer',
+			resourceId: 'doc3',
+			resourceType: 'document',
+			subjectId: 'carol',
+			subjectType: 'user'
+		});
+
+		await check(tinyConfig, {
+			relation: 'viewer',
+			resourceId: 'doc3',
+			resourceType: 'document',
+			subjectId: 'carol',
+			subjectType: 'user'
+		});
+		expect(redis.store.size).toBe(1);
+
+		// Wait past TTL; the next get() should return null after the prune.
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		const after = await check(tinyConfig, {
+			relation: 'viewer',
+			resourceId: 'doc3',
+			resourceType: 'document',
+			subjectId: 'carol',
+			subjectType: 'user'
+		});
+		expect(after).toBe(true);
+		// Warmed again after the TTL miss.
+		expect(redis.store.size).toBe(1);
+	});
+
+	test('clear() is a no-op when the client lacks keys() (TTL still bounds staleness)', async () => {
+		// Strip the `keys` capability to simulate a minimal RedisLike client.
+		const minimal: RedisFgaCacheClient = {
+			del: redis.del,
+			get: redis.get,
+			set: redis.set
+		};
+		const minimalCache = createRedisFgaCache(minimal, { ttlMs: 60_000 });
+		const minimalConfig: FgaConfig = {
+			cache: minimalCache,
+			schema,
+			warrantStore: createInMemoryWarrantStore()
+		};
+
+		await writeWarrant(minimalConfig, {
+			relation: 'viewer',
+			resourceId: 'doc4',
+			resourceType: 'document',
+			subjectId: 'dave',
+			subjectType: 'user'
+		});
+		await check(minimalConfig, {
+			relation: 'viewer',
+			resourceId: 'doc4',
+			resourceType: 'document',
+			subjectId: 'dave',
+			subjectType: 'user'
+		});
+		const cacheSizeBefore = redis.store.size;
+
+		// writeWarrant calls clear(); without keys(), the entries linger until TTL.
+		await writeWarrant(minimalConfig, {
+			relation: 'viewer',
+			resourceId: 'doc5',
+			resourceType: 'document',
+			subjectId: 'dave',
+			subjectType: 'user'
+		});
+		expect(redis.store.size).toBeGreaterThanOrEqual(cacheSizeBefore);
+	});
+});


### PR DESCRIPTION
Closes the multi-instance FGA item from the post-stable adoption-infrastructure plan. createInMemoryCheckCache is per-instance; this adds a Redis-backed adapter so a permission check computed on instance A also hits cache on instance B.

## API
```ts
import { createRedisFgaCache, type RedisFgaCacheClient } from '@absolutejs/auth';

const cache = createRedisFgaCache(redis, { ttlMs: 5000, keyPrefix: 'auth:fga:' });
const config: FgaConfig = { cache, schema, warrantStore };
```

`keys(pattern)` on the client is optional. With it, `clear()` scan-and-deletes the prefixed namespace so a `writeWarrant` on any instance takes effect immediately on all. Without it, `clear()` no-ops and stale entries linger up to `ttlMs` (fine for low-write-frequency setups).

## Type widening
`FgaCache.get` went from `boolean | undefined` to `boolean | undefined | Promise<...>` so a network-backed cache can implement the contract; `set` and `clear` may also return promises. The one consumer in `check()` now awaits `get()`. The existing `createInMemoryCheckCache` remains sync; no consumer behavior changes for in-memory paths.

## Tests
4 new in `tests/fgaRedisCache.test.ts` using a fake in-memory RedisLike shim — cross-instance cache hit, writeWarrant-triggered clear, TTL expiry forces a real check, clear() no-op when keys() is missing.

**351 / 351 tests pass.** Typecheck + lint clean.

## Version
0.33.0 → 0.34.0 (minor — additive).