### PR TITLE
feat: OpenTelemetry instrumentation (0.35.0-beta.0, G1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,8 @@
       "devDependencies": {
         "@absolutejs/absolute": "^0.19.0-beta.1023",
         "@eslint/js": "^10.0.1",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/bun": "1.2.9",
         "@types/react": "^19.0.0",
@@ -33,9 +35,15 @@
       "peerDependencies": {
         "elysia": ">= 1.4.26",
         "react": ">=18 <20",
+        "solid-js": ">=1.8",
+        "svelte": ">=4",
+        "vue": ">=3.4",
       },
       "optionalPeers": [
         "react",
+        "solid-js",
+        "svelte",
+        "vue",
       ],
     },
   },
@@ -101,6 +109,16 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.0", "", { "dependencies": { "@types/node": "^22.10.2", "@types/pg": "^8.8.0" } }, "sha512-XWmEeWpBXIoksZSDN74kftfTnXFEGZ3iX8jbANWBc+ag6dsiQuvuR4LgB0WdCOKMb5AQgjqgufc0TgAsZubUYw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@petamoriken/float16": ["@petamoriken/float16@3.9.2", "", {}, "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.34.0",
+	"version": "0.35.0-beta.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {
@@ -28,6 +28,7 @@
 	],
 	"types": "./dist/index.d.ts",
 	"peerDependencies": {
+		"@opentelemetry/api": ">=1.7",
 		"elysia": ">= 1.4.26",
 		"react": ">=18 <20",
 		"solid-js": ">=1.8",
@@ -35,6 +36,9 @@
 		"vue": ">=3.4"
 	},
 	"peerDependenciesMeta": {
+		"@opentelemetry/api": {
+			"optional": true
+		},
 		"react": {
 			"optional": true
 		},
@@ -57,6 +61,8 @@
 	"devDependencies": {
 		"@absolutejs/absolute": "^0.19.0-beta.1023",
 		"@eslint/js": "^10.0.1",
+		"@opentelemetry/api": "^1.9.1",
+		"@opentelemetry/sdk-trace-base": "^2.7.1",
 		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/bun": "1.2.9",
 		"@types/react": "^19.0.0",

--- a/src/credentials/login.ts
+++ b/src/credentials/login.ts
@@ -6,6 +6,7 @@ import { isLegacyHash } from './legacyHashers';
 import { createSessionCompatibilityLayer } from '../session/access';
 import { persistWhen, promoteToSession } from '../session/promote';
 import { sessionStore } from '../session/state';
+import { withSpan } from '../telemetry/tracing';
 import { userSessionIdTypebox } from '../typebox';
 import { resolveCookieSecure } from '../utils';
 import {
@@ -38,7 +39,8 @@ export const credentialsLogin = <UserType>({
 			request,
 			status,
 			store: { session, unregisteredSession }
-		}) => {
+		}) =>
+		withSpan('auth.credentials.login', undefined, async (span) => {
 			// Build the loose request-context bag we expose to `isMfaRequired` so
 			// the consumer can adapt the gate per-request (e.g. plug in `scoreRisk`).
 			const headerBag: Record<string, string | undefined> = {};
@@ -100,6 +102,10 @@ export const credentialsLogin = <UserType>({
 			}
 
 			await lockoutGuard?.recordSuccess(normalizedEmail);
+			// Note: consumers can attach an `auth.user.sub` attribute from inside
+			// their `onCredentialsLoginSuccess` hook by wrapping with `withSpan`;
+			// we can't safely access UserType-internal fields from generic code.
+			void span;
 
 			// Migration upgrade path: imported users that came in with a non-native
 			// hash (Auth0 PBKDF2, Cognito SHA-256, custom scrypt, etc.) get their
@@ -164,7 +170,7 @@ export const credentialsLogin = <UserType>({
 			await onCredentialsLoginSuccess?.({ user, userSessionId });
 
 			return status('OK', { passwordCompromised, status: 'authenticated' });
-		},
+		}),
 		{
 			body: t.Object({ email: t.String(), password: t.String() }),
 			cookie: t.Cookie({ user_session_id: userSessionIdTypebox })

--- a/src/credentials/register.ts
+++ b/src/credentials/register.ts
@@ -9,6 +9,7 @@ import {
 	DEFAULT_VERIFICATION_TOKEN_TTL_MS
 } from './config';
 import { promoteToSession } from '../session/promote';
+import { withSpan } from '../telemetry/tracing';
 import { evaluatePassword } from './passwordPolicy';
 
 export const credentialsRegister = <UserType>({
@@ -32,7 +33,8 @@ export const credentialsRegister = <UserType>({
 			cookie: { user_session_id },
 			status,
 			store: { session }
-		}) => {
+		}) =>
+		withSpan('auth.credentials.register', undefined, async () => {
 			const normalizedEmail = email.trim().toLowerCase();
 			if (!normalizedEmail.includes('@')) {
 				return status('Bad Request', 'A valid email is required');
@@ -105,7 +107,7 @@ export const credentialsRegister = <UserType>({
 			await onCredentialsLoginSuccess?.({ user: created, userSessionId });
 
 			return status('Created', { status: 'authenticated' });
-		},
+		}),
 		{
 			// `additionalProperties` lets extra signup fields (e.g. given_name)
 			// flow through to onCreateCredentialUser for profile capture.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { oidcSsoRoutes } from './sso/oidcRoutes';
 import { samlSsoRoutes } from './sso/samlRoutes';
 import { webauthnRoutes } from './webauthn/routes';
 import { createWebhookDispatcher } from './webhooks/dispatcher';
+import { initTracing } from './telemetry/tracing';
 import { AuthConfig, ClientProviders } from './types';
 import { resolveCookieSecure } from './utils';
 
@@ -76,6 +77,7 @@ export const auth = async <UserType>({
 	webauthn,
 	webhooks,
 	htmx,
+	tracing,
 	resolveAuthIntent,
 	onAuthorizeSuccess,
 	onAuthorizeError,
@@ -94,6 +96,7 @@ export const auth = async <UserType>({
 	onRevocationError,
 	onSessionCleanup
 }: AuthConfig<UserType>) => {
+	if (tracing !== undefined) await initTracing(tracing);
 	const clientProviders: ClientProviders = await buildClientProviders(
 		providersConfiguration,
 		createOAuth2Client
@@ -698,6 +701,11 @@ export {
 	createRedisFgaCache,
 	type RedisFgaCacheClient
 } from './fga/redisCheckCache';
+export {
+	initTracing,
+	withSpan,
+	type TracingConfig
+} from './telemetry/tracing';
 export {
 	createNeonWarrantStore,
 	createPostgresWarrantStore,

--- a/src/mfa/challenge.ts
+++ b/src/mfa/challenge.ts
@@ -3,6 +3,7 @@ import { verifyTotp } from '../crypto';
 import { createSessionCompatibilityLayer } from '../session/access';
 import { persistWhen } from '../session/promote';
 import { sessionStore } from '../session/state';
+import { withSpan } from '../telemetry/tracing';
 import { userSessionIdTypebox } from '../typebox';
 import { resolveCookieSecure } from '../utils';
 import { consumeBackupCode } from './backupCodes';
@@ -28,7 +29,8 @@ export const mfaChallenge = <UserType>({
 			cookie: { user_session_id },
 			status,
 			store: { session, unregisteredSession }
-		}) => {
+		}) =>
+		withSpan('auth.mfa.challenge', undefined, async () => {
 			const compatibilityLayer = await createSessionCompatibilityLayer({
 				authSessionStore,
 				userSessionId: user_session_id.value
@@ -106,7 +108,7 @@ export const mfaChallenge = <UserType>({
 			await onMfaChallengeSuccess?.({ user, userSessionId });
 
 			return status('OK', { status: 'authenticated' });
-		},
+		}),
 		{
 			body: t.Object({ code: t.String() }),
 			cookie: t.Cookie({ user_session_id: userSessionIdTypebox })

--- a/src/routes/callback.ts
+++ b/src/routes/callback.ts
@@ -5,6 +5,7 @@ import { resolveClientProviderEntry } from '../providers/clients';
 import { createSessionCompatibilityLayer } from '../session/access';
 import { sessionStore } from '../session/state';
 import type { AuthSessionStore } from '../session/types';
+import { withSpan } from '../telemetry/tracing';
 import { isAuthIntent, isNonEmptyString } from '../typeGuards';
 import {
 	authClientOption,
@@ -63,7 +64,8 @@ export const callback = <UserType>({
 				auth_intent
 			},
 			query: { code, state: callback_state }
-		}) => {
+		}) =>
+		withSpan('auth.oauth.callback', { 'auth.provider': auth_provider?.value }, async () => {
 			if (
 				stored_state === undefined ||
 				code_verifier === undefined ||
@@ -230,7 +232,7 @@ export const callback = <UserType>({
 			}
 
 			return redirect(originUrl);
-		},
+		}),
 		{
 			cookie: t.Cookie({
 				auth_client: authClientOption,

--- a/src/routes/signout.ts
+++ b/src/routes/signout.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from 'elysia';
 import { createSessionCompatibilityLayer } from '../session/access';
 import { sessionStore } from '../session/state';
 import type { AuthSessionStore } from '../session/types';
+import { withSpan } from '../telemetry/tracing';
 import { authProviderOption } from '../typebox';
 import { OnSignOut, RouteString } from '../types';
 
@@ -41,7 +42,8 @@ export const signout = <UserType>({
 			status,
 			store: { session },
 			cookie: { user_session_id, auth_provider }
-		}) => {
+		}) =>
+		withSpan('auth.signout', { 'auth.provider': auth_provider?.value }, async () => {
 			if (user_session_id === undefined) {
 				return status('Bad Request', 'Cookies are missing');
 			}
@@ -92,7 +94,7 @@ export const signout = <UserType>({
 			auth_provider?.remove();
 
 			return new Response(null, { status: 204 });
-		},
+		}),
 		{
 			cookie: t.Cookie({
 				auth_provider: t.Optional(authProviderOption),

--- a/src/telemetry/tracing.ts
+++ b/src/telemetry/tracing.ts
@@ -1,0 +1,84 @@
+// OpenTelemetry instrumentation for the package. OTel is the CNCF vendor-neutral standard
+// for distributed tracing (the OpenTracing + OpenCensus merger); pipe the spans into
+// Datadog / Honeycomb / Grafana Tempo / Sentry / Jaeger / New Relic / whichever APM you
+// already pay for. `@opentelemetry/api` is an OPTIONAL peer dep — consumers that don't
+// configure tracing never load it. Consumers that do pass `tracing.tracerProvider` once
+// to `auth()`, and every wrapped call site becomes a real span; everything else stays
+// noop with no runtime cost beyond a function call.
+//
+// Span names follow the `auth.<surface>.<flow>` convention (e.g. `auth.credentials.login`,
+// `auth.oauth.callback`, `auth.mfa.challenge`, `auth.webhook.deliver`). Standard attribute
+// names: `auth.flow` (the high-level operation), `auth.user.sub` (when known), `auth.session.id`
+// (when known), `auth.provider` (OAuth provider name), and the usual `http.method` /
+// `http.status_code` when meaningful.
+
+import type {
+	Attributes,
+	Span,
+	Tracer,
+	TracerProvider
+} from '@opentelemetry/api';
+
+export type TracingConfig = {
+	/** Plug in your `@opentelemetry/sdk-trace-node` (or `-web` / `-bun`) TracerProvider
+	 *  here. When omitted, every `withSpan` call short-circuits and the package never
+	 *  loads `@opentelemetry/api`. */
+	tracerProvider: TracerProvider;
+	/** Service name attribute attached to every span. Defaults to `@absolutejs/auth`. */
+	serviceName?: string;
+};
+
+const DEFAULT_SERVICE_NAME = '@absolutejs/auth';
+
+type SpanWork<Result> = (span: Span | undefined) => Promise<Result>;
+type WithSpanFn = <Result>(
+	name: string,
+	attributes: Attributes | undefined,
+	work: SpanWork<Result>
+) => Promise<Result>;
+
+const noopWithSpan: WithSpanFn = (_name, _attributes, work) => work(undefined);
+
+let activeWithSpan: WithSpanFn = noopWithSpan;
+
+// Reset hook for tests — restores the noop implementation. Not part of the public API
+// surface beyond tests / advanced re-init scenarios.
+export const __resetTracingForTests = () => {
+	activeWithSpan = noopWithSpan;
+};
+
+// One-shot initializer. Called from `auth()` when `tracing` is configured. Dynamic-imports
+// `@opentelemetry/api` so consumers without the dep installed pay nothing.
+export const initTracing = async (config: TracingConfig) => {
+	const otel = await import('@opentelemetry/api');
+	const tracer: Tracer = config.tracerProvider.getTracer(
+		config.serviceName ?? DEFAULT_SERVICE_NAME
+	);
+
+	activeWithSpan = async (name, attributes, work) => {
+		const span = tracer.startSpan(name, { attributes });
+		try {
+			const result = await otel.context.with(
+				otel.trace.setSpan(otel.context.active(), span),
+				() => work(span)
+			);
+			span.setStatus({ code: otel.SpanStatusCode.OK });
+
+			return result;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'unknown';
+			if (error instanceof Error) span.recordException(error);
+			span.setStatus({ code: otel.SpanStatusCode.ERROR, message });
+			throw error;
+		} finally {
+			span.end();
+		}
+	};
+};
+
+// Wrap an async unit of work in a span. No-op when `initTracing` hasn't been called,
+// so adding `withSpan(...)` at a call site is zero-cost for consumers without tracing.
+// The optional `span` argument lets the work add attributes mid-flight (e.g. `auth.user.sub`
+// when it's resolved from a lookup) without re-importing OTel at the call site.
+export const withSpan: WithSpanFn = (name, attributes, work) =>
+	activeWithSpan(name, attributes, work);

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ import type { ScimConfig } from './scim/config';
 import type { SessionsConfig } from './session/sessionsConfig';
 import type { AuthSessionStore } from './session/types';
 import type { SSOConfig } from './sso/config';
+import type { TracingConfig } from './telemetry/tracing';
 import type { WebAuthnConfig } from './webauthn/config';
 import type { WebhooksConfig } from './webhooks/config';
 
@@ -360,6 +361,13 @@ export type AuthConfig<UserType> = {
 	 *  dev server. If you run prod without setting `NODE_ENV=production`, set
 	 *  `cookieSecure: true` explicitly. */
 	cookieSecure?: boolean;
+	/** OpenTelemetry instrumentation. Pass your configured `TracerProvider` (from
+	 *  `@opentelemetry/sdk-trace-node` / `-web` / `-bun`) and the package emits spans for
+	 *  every key flow: `auth.credentials.login`, `auth.oauth.callback`, `auth.mfa.challenge`,
+	 *  `auth.webhook.deliver`, etc. Pipe the spans into Datadog / Honeycomb / Grafana Tempo /
+	 *  Sentry / Jaeger / whichever APM you already pay for. `@opentelemetry/api` is an
+	 *  OPTIONAL peer dep — consumers that leave `tracing` unset never load it. */
+	tracing?: TracingConfig;
 	authorizeRoute?: AuthorizeRoute;
 	profileRoute?: RouteString;
 	callbackRoute?: RouteString;

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -14,6 +14,7 @@ import type {
 	WebhookEndpoint,
 	WebhookEvent
 } from './types';
+import { withSpan } from '../telemetry/tracing';
 
 const defaultSleep = (delayMs: number) =>
 	// eslint-disable-next-line promise/avoid-new -- a setTimeout-backed delay needs the bare Promise constructor
@@ -36,17 +37,30 @@ const attemptOnce = async ({
 	timeoutMs: number;
 	timestamp: string;
 }) => {
-	const response = await fetchImpl(endpoint.url, {
-		body: payload,
-		headers: {
-			'content-type': 'application/json',
-			'webhook-id': envelope.id,
-			'webhook-signature': signature,
-			'webhook-timestamp': timestamp
+	const response = await withSpan(
+		'auth.webhook.deliver',
+		{
+			'auth.webhook.event': envelope.type,
+			'auth.webhook.url': endpoint.url,
+			'http.method': 'POST'
 		},
-		method: 'POST',
-		signal: AbortSignal.timeout(timeoutMs)
-	});
+		async (span) => {
+			const result = await fetchImpl(endpoint.url, {
+				body: payload,
+				headers: {
+					'content-type': 'application/json',
+					'webhook-id': envelope.id,
+					'webhook-signature': signature,
+					'webhook-timestamp': timestamp
+				},
+				method: 'POST',
+				signal: AbortSignal.timeout(timeoutMs)
+			});
+			span?.setAttribute('http.status_code', result.status);
+
+			return result;
+		}
+	);
 	if (!response.ok) {
 		throw new Error(`Webhook delivery returned ${response.status}`);
 	}

--- a/tests/tracing.test.ts
+++ b/tests/tracing.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	BasicTracerProvider,
+	InMemorySpanExporter,
+	SimpleSpanProcessor
+} from '@opentelemetry/sdk-trace-base';
+import { Elysia } from 'elysia';
+import type { CredentialsConfig } from '../src/credentials/config';
+import { credentialsLogin } from '../src/credentials/login';
+import { credentialsRegister } from '../src/credentials/register';
+import { createInMemoryCredentialStore } from '../src/credentials/inMemoryCredentialStore';
+import { signout } from '../src/routes/signout';
+import {
+	__resetTracingForTests,
+	initTracing,
+	withSpan
+} from '../src/telemetry/tracing';
+
+// Tracing is added 0.35.0-beta.0. These tests use OTel's BasicTracerProvider with an
+// InMemorySpanExporter so the assertions can read the spans the package emits without
+// hitting a real APM. Without `initTracing`, `withSpan` is a no-op + the existing
+// non-tracing flows keep working (covered by every other test file). The "no tracer
+// configured" assertion below also locks that in.
+
+type TestUser = { email: string; sub: string };
+
+const buildExporter = () => {
+	const exporter = new InMemorySpanExporter();
+	const provider = new BasicTracerProvider({
+		spanProcessors: [new SimpleSpanProcessor(exporter)]
+	});
+
+	return { exporter, provider };
+};
+
+const buildApp = () => {
+	const credentialStore = createInMemoryCredentialStore();
+	const users = new Map<string, TestUser>();
+	const config: CredentialsConfig<TestUser> = {
+		credentialStore,
+		passwordPolicy: { minLength: 8 },
+		getUserByEmail: (email) => users.get(email) ?? null,
+		onCreateCredentialUser: ({ email }) => {
+			const user: TestUser = { email, sub: `user:${email}` };
+			users.set(email, user);
+
+			return user;
+		},
+		onSendEmail: () => undefined
+	};
+
+	return new Elysia()
+		.use(credentialsRegister(config))
+		.use(credentialsLogin(config))
+		.use(signout<TestUser>({ onSignOut: undefined }));
+};
+
+const postJson = (
+	app: { handle: (request: Request) => Promise<Response> },
+	path: string,
+	body: unknown
+) =>
+	app.handle(
+		new Request(`http://localhost${path}`, {
+			body: JSON.stringify(body),
+			headers: { 'content-type': 'application/json' },
+			method: 'POST'
+		})
+	);
+
+describe('OpenTelemetry instrumentation', () => {
+	afterEach(() => {
+		__resetTracingForTests();
+	});
+
+	test('withSpan is a no-op when initTracing was never called', async () => {
+		// Sanity: calling withSpan returns the work's value, no error, no provider needed.
+		const result = await withSpan('test.noop', { foo: 'bar' }, async () => 42);
+		expect(result).toBe(42);
+	});
+
+	test('credentials login emits an auth.credentials.login span', async () => {
+		const { exporter, provider } = buildExporter();
+		await initTracing({ tracerProvider: provider });
+
+		const app = buildApp();
+		await postJson(app, '/auth/register', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		exporter.reset();
+
+		const loginResponse = await postJson(app, '/auth/login', {
+			email: 'a@b.com',
+			password: 'supersecret'
+		});
+		expect(loginResponse.status).toBe(200);
+
+		const spans = exporter.getFinishedSpans();
+		const loginSpan = spans.find(
+			(span) => span.name === 'auth.credentials.login'
+		);
+		expect(loginSpan).toBeDefined();
+		expect(loginSpan?.status.code).toBe(1); // SpanStatusCode.OK
+	});
+
+	test('credentials register emits an auth.credentials.register span', async () => {
+		const { exporter, provider } = buildExporter();
+		await initTracing({ tracerProvider: provider });
+
+		const app = buildApp();
+		const response = await postJson(app, '/auth/register', {
+			email: 'b@c.com',
+			password: 'supersecret'
+		});
+		expect(response.status).toBe(201);
+
+		const spans = exporter.getFinishedSpans();
+		expect(
+			spans.some((span) => span.name === 'auth.credentials.register')
+		).toBe(true);
+	});
+
+	test('signout emits an auth.signout span', async () => {
+		const { exporter, provider } = buildExporter();
+		await initTracing({ tracerProvider: provider });
+
+		const app = buildApp();
+		await postJson(app, '/auth/register', {
+			email: 'c@d.com',
+			password: 'supersecret'
+		});
+		const loginResponse = await postJson(app, '/auth/login', {
+			email: 'c@d.com',
+			password: 'supersecret'
+		});
+		const setCookie = loginResponse.headers.get('set-cookie') ?? '';
+		const match = setCookie.match(/user_session_id=([^;]+)/);
+		const cookie = `user_session_id=${match?.[1] ?? ''}`;
+		exporter.reset();
+
+		await app.handle(
+			new Request('http://localhost/oauth2/signout', {
+				headers: { cookie },
+				method: 'DELETE'
+			})
+		);
+
+		const spans = exporter.getFinishedSpans();
+		expect(spans.some((span) => span.name === 'auth.signout')).toBe(true);
+	});
+
+	test('explicit withSpan call from consumer code is captured', async () => {
+		const { exporter, provider } = buildExporter();
+		await initTracing({ tracerProvider: provider });
+
+		const result = await withSpan(
+			'consumer.action',
+			{ 'auth.flow': 'custom' },
+			async (span) => {
+				span?.setAttribute('extra', 'thing');
+
+				return 'done';
+			}
+		);
+		expect(result).toBe('done');
+
+		const spans = exporter.getFinishedSpans();
+		const consumerSpan = spans.find((span) => span.name === 'consumer.action');
+		expect(consumerSpan).toBeDefined();
+		expect(consumerSpan?.attributes['auth.flow']).toBe('custom');
+		expect(consumerSpan?.attributes.extra).toBe('thing');
+	});
+});
+
+describe('withSpan error path', () => {
+	let exporter: InMemorySpanExporter;
+	beforeEach(async () => {
+		const { exporter: builtExporter, provider } = buildExporter();
+		exporter = builtExporter;
+		await initTracing({ tracerProvider: provider });
+	});
+	afterEach(() => {
+		__resetTracingForTests();
+	});
+
+	test('a throwing work fn records the exception and marks the span ERROR', async () => {
+		await expect(
+			withSpan('boom', undefined, async () => {
+				throw new Error('blew up');
+			})
+		).rejects.toThrow('blew up');
+
+		const spans = exporter.getFinishedSpans();
+		const boom = spans.find((span) => span.name === 'boom');
+		expect(boom).toBeDefined();
+		expect(boom?.status.code).toBe(2); // SpanStatusCode.ERROR
+		expect(boom?.events.some((event) => event.name === 'exception')).toBe(
+			true
+		);
+	});
+});


### PR DESCRIPTION
First half of the 0.35.0 cycle (G1 from ROADMAP-NEXT.md). G2 (Drizzle migrations + `auth migrate` CLI) ships next as the second half of the cycle, then promotes to stable 0.35.0.

## What it does
Adds OpenTelemetry spans around the key auth flows. OTel is the CNCF vendor-neutral standard for distributed tracing — pipe the same spans into Datadog / Honeycomb / Grafana Tempo / Sentry / Jaeger / whichever APM you already pay for. No vendor lock-in.

## API
```ts
import { auth } from '@absolutejs/auth';
import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';

const provider = new NodeTracerProvider({ ... });
await auth<User>({
  providersConfiguration: {},
  tracing: { tracerProvider: provider },
  // ...
});
```

Plus a public `withSpan(name, attributes, work)` helper so consumers can wrap their own `onCallbackSuccess` / `onSignOut` / etc. handlers in spans that participate in the same trace tree.

## Spans (this beta)
- `auth.credentials.login`
- `auth.credentials.register`
- `auth.oauth.callback` (attribute: `auth.provider`)
- `auth.mfa.challenge`
- `auth.signout` (attribute: `auth.provider` when present)
- `auth.webhook.deliver` (attributes: `auth.webhook.event`/`url` + `http.method`/`status_code`)

More span sites can be added in follow-ups without API change.

## Architecture
- `@opentelemetry/api` is an **optional** peer dep. Consumers that never set `tracing.tracerProvider` never load it (dynamic import gates the actual require to `initTracing`).
- When tracing is unset, `withSpan` is a noop function that just runs the work — zero runtime cost beyond a function call.
- When tracing is set, `initTracing` runs once at `auth()` boot, dynamic-imports `@opentelemetry/api`, and swaps the helper for a real span-creating impl with proper context propagation.
- Errors inside `withSpan` record the exception + mark the span `ERROR`; successes mark it `OK`.

## Tests
6 new in `tests/tracing.test.ts` using OTel's `BasicTracerProvider` + `InMemorySpanExporter` — no-op without tracer, login/register/signout span emission, attribute set, consumer-side `withSpan` integration, error-path span status + exception event.

**357 / 357 tests pass.** Typecheck + lint clean.

## Version
0.34.0 → 0.35.0-beta.0 (minor, beta — additive).