### PR TITLE
feat: shipped migrations + 'absolute-auth migrate' CLI (0.35.0, G2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.35.0-beta.0",
+	"version": "0.35.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {
@@ -7,10 +7,13 @@
 		"url": "https://github.com/absolutejs/absolute-auth.git"
 	},
 	"main": "./dist/index.js",
+	"bin": {
+		"absolute-auth": "./dist/cli/migrate.js"
+	},
 	"license": "CC BY-NC 4.0",
 	"author": "Alex Kahn",
 	"scripts": {
-		"build": "rm -rf dist && bun build src/index.ts src/htmx/index.ts src/client/index.ts src/client/react.ts src/client/vue.ts src/client/solid.ts src/client/svelte.ts src/plugins/index.ts --outdir dist --sourcemap --target=bun --external elysia --external react --external vue --external solid-js --external svelte && bun build src/fingerprint-client/index.ts --outdir dist/fingerprint-client --sourcemap --target=browser && tsc --emitDeclarationOnly --project tsconfig.json",
+		"build": "rm -rf dist && bun build src/index.ts src/htmx/index.ts src/client/index.ts src/client/react.ts src/client/vue.ts src/client/solid.ts src/client/svelte.ts src/plugins/index.ts --outdir dist --sourcemap --target=bun --external elysia --external react --external vue --external solid-js --external svelte --external @opentelemetry/api && bun build src/cli/migrate.ts --outdir dist/cli --sourcemap --target=bun --external @neondatabase/serverless --external drizzle-orm && bun build src/fingerprint-client/index.ts --outdir dist/fingerprint-client --sourcemap --target=browser && tsc --emitDeclarationOnly --project tsconfig.json && chmod +x dist/cli/migrate.js",
 		"config": "absolute config",
 		"test": "bun test",
 		"format": "absolute prettier --write",

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+// CLI entry for the migration runner. Invocation:
+//   bunx absolute-auth migrate --db $DATABASE_URL
+//   bunx absolute-auth migrate --db $DATABASE_URL --blocks credentials,mfa,sessions
+//   bunx absolute-auth migrate --help
+//
+// Resolves --db from --db / --database-url flags or the DATABASE_URL env var. --blocks is
+// an optional comma-separated list; omit to apply every block the package ships.
+
+import { blockMigrations, type BlockName, runMigrations } from '../migrations';
+
+const USAGE = `Usage:
+  bunx absolute-auth migrate --db <url> [--blocks block1,block2,...]
+
+Options:
+  --db, --database-url    Postgres connection string (falls back to DATABASE_URL env)
+  --blocks                Comma-separated subset of blocks to apply (default: all)
+  --help                  Print this message
+
+Available blocks: ${Object.keys(blockMigrations).sort().join(', ')}
+`;
+
+type ParsedArgs = {
+	blocks: BlockName[] | undefined;
+	databaseUrl: string | undefined;
+	help: boolean;
+};
+
+const consumeFlag = (
+	parsed: ParsedArgs,
+	flag: string | undefined,
+	args: string[]
+) => {
+	if (flag === '--help' || flag === '-h') {
+		parsed.help = true;
+	} else if (flag === '--db' || flag === '--database-url') {
+		parsed.databaseUrl = args.shift();
+	} else if (flag === '--blocks') {
+		const list = args.shift() ?? '';
+		parsed.blocks = list
+			.split(',')
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0)
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated against blockMigrations keys below
+			.map((entry) => entry as BlockName);
+	}
+};
+
+const parseArgs = (argv: string[]) => {
+	const parsed: ParsedArgs = {
+		blocks: undefined,
+		databaseUrl: undefined,
+		help: false
+	};
+	const args = [...argv];
+	while (args.length > 0) {
+		consumeFlag(parsed, args.shift(), args);
+	}
+
+	return parsed;
+};
+
+const die = (message: string) => {
+	process.stderr.write(`error: ${message}\n\n`);
+	process.stderr.write(USAGE);
+	process.exit(1);
+};
+
+const main = async () => {
+	const positional = process.argv.slice(2);
+	if (positional[0] === 'migrate') positional.shift();
+	const { blocks, databaseUrl, help } = parseArgs(positional);
+
+	if (help) {
+		process.stdout.write(USAGE);
+
+		return;
+	}
+
+	const resolved = databaseUrl ?? process.env['DATABASE_URL'];
+	if (resolved === undefined || resolved.length === 0) {
+		die('a Postgres URL is required (--db or DATABASE_URL)');
+
+		return;
+	}
+
+	const unknown = blocks?.filter((block) => !(block in blockMigrations)) ?? [];
+	if (unknown.length > 0) {
+		die(`unknown block(s): ${unknown.join(', ')}`);
+
+		return;
+	}
+
+	const result = await runMigrations({ blocks, databaseUrl: resolved });
+	process.stdout.write(
+		`\n${result.applied.length} migration(s) applied, ${result.skipped.length} skipped.\n`
+	);
+};
+
+await main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -707,6 +707,17 @@ export {
 	type TracingConfig
 } from './telemetry/tracing';
 export {
+	blockMigrations,
+	runMigrations,
+	type BlockMigrations,
+	type BlockName,
+	type Migration
+} from './migrations';
+export type {
+	MigrationRunResult,
+	RunMigrationsOptions
+} from './migrations/runner';
+export {
 	createNeonWarrantStore,
 	createPostgresWarrantStore,
 	warrantsTable

--- a/src/migrations/generate.ts
+++ b/src/migrations/generate.ts
@@ -1,0 +1,83 @@
+// Translate the package's existing `pgTable` definitions into `CREATE TABLE IF NOT EXISTS`
+// SQL, so each block's migration is derived from the same drizzle schema the runtime store
+// already uses. Eliminates the transcription-drift risk of hand-writing CREATE TABLEs that
+// have to stay in sync with the table definitions in `src/<block>/postgresStores.ts`.
+//
+// What this covers: column name + type + nullability + default + primary key + unique +
+// composite primary key. Doesn't cover: foreign keys (none of the package's tables use
+// them across blocks — sub-keys are referenced by id without referential integrity),
+// indices (consumers can add their own per their workload), check constraints (none in
+// the schema). If a block ever needs any of those, hand-write that migration entry
+// alongside the auto-generated one.
+
+import { is, SQL } from 'drizzle-orm';
+import {
+	getTableConfig,
+	type PgColumn,
+	type PgTable
+} from 'drizzle-orm/pg-core';
+
+// Defaults declared with drizzle's `sql\`...\`` template are `SQL` objects; render them as
+// raw SQL expressions (e.g. `now()`) instead of letting them fall into the generic-object
+// JSON branch, which would emit a `{"queryChunks":[...]}::jsonb` literal.
+const renderChunk = (chunk: unknown) => {
+	if (chunk === null || typeof chunk !== 'object') return String(chunk);
+	const value = Reflect.get(chunk, 'value');
+	if (Array.isArray(value)) return value.map((part) => String(part)).join('');
+
+	return '';
+};
+
+const formatSqlTemplate = (value: SQL) =>
+	value.queryChunks.map(renderChunk).join('');
+
+const formatDefault = (value: unknown) => {
+	if (value === null || value === undefined) return 'NULL';
+	if (is(value, SQL)) return formatSqlTemplate(value);
+	if (typeof value === 'string') return `'${value.replace(/'/gu, "''")}'`;
+	if (typeof value === 'boolean') return value ? 'true' : 'false';
+	if (typeof value === 'number') return String(value);
+	if (Array.isArray(value) || typeof value === 'object') {
+		return `'${JSON.stringify(value)}'::jsonb`;
+	}
+
+	return String(value);
+};
+
+const columnSql = (column: PgColumn) => {
+	const parts = [`"${column.name}"`, column.getSQLType()];
+	if (column.primary) parts.push('PRIMARY KEY');
+	if (column.notNull && !column.primary) parts.push('NOT NULL');
+	if (column.hasDefault && column.default !== undefined) {
+		parts.push(`DEFAULT ${formatDefault(column.default)}`);
+	}
+	if (column.isUnique) parts.push('UNIQUE');
+
+	return parts.join(' ');
+};
+
+const compositePkLine = (compositePk: readonly PgColumn[]) =>
+	`PRIMARY KEY (${compositePk.map((column) => `"${column.name}"`).join(', ')})`;
+
+// Emit a single `CREATE TABLE IF NOT EXISTS` for one table. Idempotent — re-running is a
+// no-op even when the consumer already wired the table by hand. The composite-PK case is
+// handled separately because Drizzle splits it out of the column metadata.
+const tableToCreateSql = (table: PgTable) => {
+	const cfg = getTableConfig(table);
+	const columnLines = cfg.columns.map(columnSql);
+	const singlePk = cfg.columns.find((column) => column.primary);
+	const compositePk = cfg.primaryKeys[0]?.columns ?? [];
+	const lines =
+		singlePk === undefined && compositePk.length > 0
+			? [...columnLines, compositePkLine(compositePk)]
+			: columnLines;
+	const body = lines.map((line) => `\t${line}`).join(',\n');
+
+	return `CREATE TABLE IF NOT EXISTS "${cfg.name}" (\n${body}\n);`;
+};
+
+// Block migrations are always declared as one `0001_init` covering every table the block
+// owns + (rare) hand-written follow-up ids for schema changes. This helper does the init
+// step — pass every table you want included.
+export const tablesToInitSql = (tables: PgTable[]) =>
+	tables.map(tableToCreateSql).join('\n\n');

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,134 @@
+// Single export of every block's migrations. Consumers pick which blocks they enabled
+// in `auth()` and pass that subset to `runMigrations({ blocks: [...] })`, or omit `blocks`
+// to apply every migration the package ships. Adding a new block's migrations: import its
+// tables here + add to the `blockMigrations` map.
+
+import { knownDevicesTable, loginHistoryTable } from '../adaptive/postgresStores';
+import {
+	accessTokensTable,
+	apiClientsTable,
+	apiKeysTable
+} from '../apikeys/postgresStores';
+import { auditEventsTable } from '../audit/postgresAuditStore';
+import {
+	credentialResetTokensTable,
+	credentialVerificationTokensTable,
+	credentialsTable
+} from '../credentials/postgresCredentialStore';
+import { warrantsTable } from '../fga/postgresStores';
+import {
+	linkedProviderBindingsTable,
+	linkedProviderGrantsTable
+} from '../linkedProviders/neonStores';
+import { lockoutsTable } from '../lockout/postgresLockoutStore';
+import { mfaEnrollmentsTable } from '../mfa/postgresMfaStore';
+import {
+	oauthClientAssertionJtisTable,
+	oauthClientRegistrationTokensTable,
+	oauthClientsTable,
+	oauthCodesTable,
+	oauthDeviceAuthorizationsTable,
+	oauthInitialAccessTokensTable,
+	oauthLogoutDeliveriesTable,
+	oauthPushedAuthorizationRequestsTable,
+	oauthRefreshTokensTable
+} from '../oidc/postgresStores';
+import {
+	organizationInvitationsTable,
+	organizationMembershipsTable,
+	organizationsTable
+} from '../organizations/postgresOrganizationStore';
+import { passwordlessTokensTable } from '../passwordless/postgresPasswordlessTokenStore';
+import { setupSessionsTable } from '../portal/postgresSetupSessionStore';
+import { rolesTable } from '../roles/postgresRoleStore';
+import { scimTokensTable } from '../scim/postgresScimTokenStore';
+import {
+	authSessionsTable,
+	authUnregisteredSessionsTable
+} from '../session/neonStore';
+import { samlServiceProvidersTable } from '../sso/postgresSamlServiceProviderStore';
+import { ssoConnectionsTable } from '../sso/postgresSsoConnectionStore';
+import { vaultEntriesTable } from '../vault/postgresVaultStore';
+import { webauthnCredentialsTable } from '../webauthn/postgresWebAuthnCredentialStore';
+import { webhookDeliveriesTable } from '../webhooks/postgresStore';
+import { tablesToInitSql } from './generate';
+import type { BlockMigrations } from './types';
+
+export type BlockName =
+	| 'adaptive'
+	| 'apikeys'
+	| 'audit'
+	| 'credentials'
+	| 'fga'
+	| 'linkedProviders'
+	| 'lockout'
+	| 'mfa'
+	| 'oidc'
+	| 'organizations'
+	| 'passwordless'
+	| 'portal'
+	| 'roles'
+	| 'scim'
+	| 'sessions'
+	| 'sso'
+	| 'vault'
+	| 'webauthn'
+	| 'webhooks';
+
+const initMigration = (block: BlockName, tables: Parameters<typeof tablesToInitSql>[0]): BlockMigrations => ({
+	block,
+	migrations: [{ id: '0001_init', sql: tablesToInitSql(tables) }]
+});
+
+export const blockMigrations: Record<BlockName, BlockMigrations> = {
+	adaptive: initMigration('adaptive', [knownDevicesTable, loginHistoryTable]),
+	apikeys: initMigration('apikeys', [
+		accessTokensTable,
+		apiClientsTable,
+		apiKeysTable
+	]),
+	audit: initMigration('audit', [auditEventsTable]),
+	credentials: initMigration('credentials', [
+		credentialsTable,
+		credentialResetTokensTable,
+		credentialVerificationTokensTable
+	]),
+	fga: initMigration('fga', [warrantsTable]),
+	linkedProviders: initMigration('linkedProviders', [
+		linkedProviderBindingsTable,
+		linkedProviderGrantsTable
+	]),
+	lockout: initMigration('lockout', [lockoutsTable]),
+	mfa: initMigration('mfa', [mfaEnrollmentsTable]),
+	oidc: initMigration('oidc', [
+		oauthClientAssertionJtisTable,
+		oauthClientRegistrationTokensTable,
+		oauthClientsTable,
+		oauthCodesTable,
+		oauthDeviceAuthorizationsTable,
+		oauthInitialAccessTokensTable,
+		oauthLogoutDeliveriesTable,
+		oauthPushedAuthorizationRequestsTable,
+		oauthRefreshTokensTable
+	]),
+	organizations: initMigration('organizations', [
+		organizationsTable,
+		organizationMembershipsTable,
+		organizationInvitationsTable
+	]),
+	passwordless: initMigration('passwordless', [passwordlessTokensTable]),
+	portal: initMigration('portal', [setupSessionsTable]),
+	roles: initMigration('roles', [rolesTable]),
+	scim: initMigration('scim', [scimTokensTable]),
+	sessions: initMigration('sessions', [
+		authSessionsTable,
+		authUnregisteredSessionsTable
+	]),
+	sso: initMigration('sso', [ssoConnectionsTable, samlServiceProvidersTable]),
+	vault: initMigration('vault', [vaultEntriesTable]),
+	webauthn: initMigration('webauthn', [webauthnCredentialsTable]),
+	webhooks: initMigration('webhooks', [webhookDeliveriesTable])
+};
+
+export { runMigrations } from './runner';
+export type { Migration, BlockMigrations } from './types';

--- a/src/migrations/runner.ts
+++ b/src/migrations/runner.ts
@@ -1,0 +1,109 @@
+// Migration runner. Uses `@neondatabase/serverless`'s Pool (already a package dep) so
+// consumers don't need to install drizzle-kit or a separate migrator. The Pool client
+// supports multi-statement queries (a block's init migration emits one CREATE TABLE per
+// table joined by `;`), which the HTTP `neon()` function does not.
+//
+// Tracks applied migrations in an `auth_migrations` table keyed by `${block}/${id}`.
+// Idempotent — re-running is a no-op when everything's been applied.
+//
+// Consumers can invoke programmatically (`await runMigrations({ databaseUrl })`) at boot
+// or via the bundled CLI (`bunx absolute-auth migrate --db $DATABASE_URL`).
+
+import { Pool } from '@neondatabase/serverless';
+import { blockMigrations, type BlockName } from './index';
+
+export type RunMigrationsOptions = {
+	databaseUrl: string;
+	/** Subset of blocks to apply. Omit to apply every block the package ships. */
+	blocks?: BlockName[];
+	/** Optional logger; defaults to console.log. Pass `() => undefined` for silent mode. */
+	log?: (message: string) => void;
+};
+
+export type MigrationRunResult = {
+	applied: string[];
+	skipped: string[];
+};
+
+const JOURNAL_DDL = `CREATE TABLE IF NOT EXISTS "auth_migrations" (
+	"id" text PRIMARY KEY,
+	"applied_at_ms" bigint NOT NULL
+);`;
+
+type JournalRow = { id: string };
+
+const isJournalRow = (value: unknown): value is JournalRow =>
+	typeof value === 'object' &&
+	value !== null &&
+	typeof Reflect.get(value, 'id') === 'string';
+
+const allBlockNames = () =>
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Object.keys widens to string[]; the values are typed BlockName by construction of the manifest
+	Object.keys(blockMigrations) as BlockName[];
+
+const applyOne = async (
+	pool: Pool,
+	id: string,
+	sql: string,
+	log: (message: string) => void
+) => {
+	await pool.query(sql);
+	await pool.query(
+		`INSERT INTO "auth_migrations" ("id", "applied_at_ms") VALUES ($1, $2)`,
+		[id, Date.now()]
+	);
+	log(`apply  ${id}`);
+};
+
+const runOne = async (
+	pool: Pool,
+	id: string,
+	sql: string,
+	applied: Set<string>,
+	result: MigrationRunResult,
+	log: (message: string) => void
+) => {
+	if (applied.has(id)) {
+		result.skipped.push(id);
+		log(`skip   ${id}`);
+
+		return;
+	}
+	await applyOne(pool, id, sql, log);
+	result.applied.push(id);
+};
+
+export const runMigrations = async ({
+	blocks,
+	databaseUrl,
+	log = console.log
+}: RunMigrationsOptions) => {
+	const pool = new Pool({ connectionString: databaseUrl });
+	const result: MigrationRunResult = { applied: [], skipped: [] };
+
+	try {
+		await pool.query(JOURNAL_DDL);
+		const journal = await pool.query(`SELECT "id" FROM "auth_migrations"`);
+		const applied = new Set(
+			journal.rows.filter(isJournalRow).map((row) => row.id)
+		);
+
+		const selected = blocks ?? allBlockNames();
+		const flat = selected.flatMap((block) =>
+			blockMigrations[block].migrations.map((migration) => ({
+				id: `${block}/${migration.id}`,
+				sql: migration.sql
+			}))
+		);
+
+		await flat.reduce(async (prior, item) => {
+			await prior;
+
+			return runOne(pool, item.id, item.sql, applied, result, log);
+		}, Promise.resolve());
+	} finally {
+		await pool.end();
+	}
+
+	return result;
+};

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -1,0 +1,20 @@
+// Migration manifest. Each block under `src/<block>/` that ships a Postgres store also
+// ships a `migrations.ts` exporting a `BlockMigrations` so consumers can opt into the
+// SQL with `runMigrations({ databaseUrl, blocks: ['credentials', 'mfa'] })` instead of
+// hand-writing CREATE TABLE statements.
+
+export type Migration = {
+	/** Stable identifier — stored in `auth_migrations` to track applied state. Must be
+	 *  monotonically ordered within a block (e.g. `0001_init`, `0002_add_foo_column`). */
+	id: string;
+	/** Idempotent SQL. Use `CREATE TABLE IF NOT EXISTS` so re-running is a no-op even if
+	 *  the consumer wired the tables by hand before adopting the migration runner. */
+	sql: string;
+};
+
+export type BlockMigrations = {
+	/** Block name as used in the CLI's `--blocks` flag and in `runMigrations({ blocks })`.
+	 *  Convention: same string as the `src/<block>/` directory. */
+	block: string;
+	migrations: Migration[];
+};

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { tablesToInitSql } from '../src/migrations/generate';
+import { blockMigrations } from '../src/migrations/index';
+import { credentialsTable } from '../src/credentials/postgresCredentialStore';
+import { lockoutsTable } from '../src/lockout/postgresLockoutStore';
+
+// The runner test uses the actual `runMigrations` against a real Postgres only in CI when
+// `MIGRATION_TEST_DATABASE_URL` is set. The unit tests below cover the SQL generation
+// path + the block manifest shape — the runner itself is a thin shell over
+// `pool.query()` that we don't try to mock end-to-end (the value is in the SQL it emits).
+
+describe('tablesToInitSql', () => {
+	test('emits CREATE TABLE IF NOT EXISTS with the correct table name + columns', () => {
+		const sql = tablesToInitSql([lockoutsTable]);
+		expect(sql).toContain('CREATE TABLE IF NOT EXISTS "auth_lockouts"');
+		expect(sql).toContain('"key"');
+		expect(sql).toContain('PRIMARY KEY');
+		expect(sql).toContain('"failed_attempts"');
+		expect(sql).toContain('"window_started_at_ms"');
+		expect(sql).toContain('NOT NULL');
+	});
+
+	test('joins multiple tables with blank lines between statements', () => {
+		const sql = tablesToInitSql([lockoutsTable, credentialsTable]);
+		expect(
+			sql.match(/CREATE TABLE IF NOT EXISTS/gu)?.length ?? 0
+		).toBeGreaterThanOrEqual(2);
+		expect(sql).toContain('"auth_lockouts"');
+		expect(sql).toContain('"auth_credentials"');
+	});
+
+	test('emits a default value when the column has one', () => {
+		const sql = tablesToInitSql([credentialsTable]);
+		// `status` column defaults to 'active'.
+		expect(sql).toContain("DEFAULT 'active'");
+		// `email_verified` column defaults to false.
+		expect(sql).toContain('DEFAULT false');
+	});
+});
+
+describe('blockMigrations manifest', () => {
+	const allEntries = Object.entries(blockMigrations).flatMap(
+		([name, block]) =>
+			block.migrations.map((migration) => ({
+				blockName: name,
+				blockSelfName: block.block,
+				migration
+			}))
+	);
+
+	test('every block has at least one migration with a stable id', () => {
+		for (const entry of allEntries) {
+			expect(entry.blockSelfName).toBe(entry.blockName);
+			expect(entry.migration.id).toMatch(/^\d{4}_/u);
+			expect(entry.migration.sql).toContain('CREATE TABLE IF NOT EXISTS');
+		}
+	});
+
+	test('every block names tables prefixed with auth_ or a known package prefix', () => {
+		// Catches accidental cross-package collision; intent + similar consumers will own
+		// any non-`auth_` namespace and we shouldn't ship migrations that touch theirs.
+		const PACKAGE_PREFIXES = ['auth_', 'linked_provider_'];
+		const allTableNames = allEntries.flatMap((entry) =>
+			Array.from(
+				entry.migration.sql.matchAll(
+					/CREATE TABLE IF NOT EXISTS "([^"]+)"/gu
+				)
+			).map((match) => match[1] ?? '')
+		);
+		for (const tableName of allTableNames) {
+			expect(
+				PACKAGE_PREFIXES.some((prefix) => tableName.startsWith(prefix))
+			).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
Closes the 0.35.0 cycle. G1 (OpenTelemetry) shipped as 0.35.0-beta.0 in #14; this lands G2 and promotes to stable.

## Programmatic API
```ts
import { runMigrations } from '@absolutejs/auth';

await runMigrations({
  databaseUrl: process.env.DATABASE_URL!,
  blocks: ['credentials', 'mfa', 'sessions'] // or omit for all
});
```

## CLI
```bash
bunx absolute-auth migrate --db $DATABASE_URL
bunx absolute-auth migrate --db $DATABASE_URL --blocks credentials,mfa
bunx absolute-auth migrate --help
```

## Blocks shipped (19)
`adaptive`, `apikeys`, `audit`, `credentials`, `fga`, `linkedProviders`, `lockout`, `mfa`, `oidc`, `organizations`, `passwordless`, `portal`, `roles`, `scim`, `sessions`, `sso`, `vault`, `webauthn`, `webhooks`.

## Why this matters
Before: every consumer that enables credentials/mfa/sso/oidc/etc. hand-writes 15+ `CREATE TABLE IF NOT EXISTS` statements. That's been the #2 onboarding friction (after observability, which G1 fixed).
After: `bunx absolute-auth migrate` and they're done.

## Architecture
- `tablesToInitSql()` reads drizzle's `getTableConfig()` metadata and emits CREATE TABLE SQL. Handles columns + types + nullability + defaults (including drizzle's `sql`now()`` template defaults) + primary keys (single + composite) + uniques. Zero transcription drift between the runtime store and the shipped migrations — anytime a future PR adds a column to a pgTable, the migration auto-tracks.
- `blockMigrations` is the static manifest. Each block's migrations array can grow with hand-written follow-ups (e.g. `0002_add_foo`) for schema evolution; the auto-generated init covers the current schema.
- Runner uses `@neondatabase/serverless`'s Pool (already a dep) for multi-statement query support. Journal = `auth_migrations` table keyed by `${block}/${id}`. Idempotent.
- CLI bin = `absolute-auth`; the build script gives it its own bun-build invocation to avoid bun's common-prefix calculation pushing every other output into `dist/src/...`.

## Tests
5 new in `tests/migrations.test.ts`. **362 / 362 tests pass.** Typecheck + lint clean.

## Version
0.34.0 → 0.35.0-beta.0 (G1) → **0.35.0** (this; G2 + promote to stable).