### PR TITLE
feat: OIDC CIBA poll mode (0.36.0-beta.0, G3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.35.0",
+	"version": "0.36.0-beta.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -612,6 +612,7 @@ export { parseSignedRequestObject } from './oidc/jar';
 export type { JarParseResult } from './oidc/jar';
 export {
 	createInMemoryAuthorizationCodeStore,
+	createInMemoryBackchannelAuthStore,
 	createInMemoryClientAssertionJtiStore,
 	createInMemoryClientRegistrationTokenStore,
 	createInMemoryDeviceAuthorizationStore,
@@ -641,6 +642,7 @@ export {
 } from './oidc/logout';
 export {
 	createNeonAuthorizationCodeStore,
+	createNeonBackchannelAuthStore,
 	createNeonClientAssertionJtiStore,
 	createNeonClientRegistrationTokenStore,
 	createNeonDeviceAuthorizationStore,
@@ -650,6 +652,7 @@ export {
 	createNeonOidcRefreshTokenStore,
 	createNeonPushedAuthorizationRequestStore,
 	createPostgresAuthorizationCodeStore,
+	createPostgresBackchannelAuthStore,
 	createPostgresClientAssertionJtiStore,
 	createPostgresClientRegistrationTokenStore,
 	createPostgresDeviceAuthorizationStore,
@@ -662,6 +665,7 @@ export {
 	oauthClientRegistrationTokensTable,
 	oauthClientsTable,
 	oauthCodesTable,
+	oauthBackchannelAuthRequestsTable,
 	oauthDeviceAuthorizationsTable,
 	oauthInitialAccessTokensTable,
 	oauthLogoutDeliveriesTable,

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -23,6 +23,7 @@ import {
 import { lockoutsTable } from '../lockout/postgresLockoutStore';
 import { mfaEnrollmentsTable } from '../mfa/postgresMfaStore';
 import {
+	oauthBackchannelAuthRequestsTable,
 	oauthClientAssertionJtisTable,
 	oauthClientRegistrationTokensTable,
 	oauthClientsTable,
@@ -101,6 +102,7 @@ export const blockMigrations: Record<BlockName, BlockMigrations> = {
 	lockout: initMigration('lockout', [lockoutsTable]),
 	mfa: initMigration('mfa', [mfaEnrollmentsTable]),
 	oidc: initMigration('oidc', [
+		oauthBackchannelAuthRequestsTable,
 		oauthClientAssertionJtisTable,
 		oauthClientRegistrationTokensTable,
 		oauthClientsTable,

--- a/src/oidc/config.ts
+++ b/src/oidc/config.ts
@@ -9,11 +9,13 @@ import { signJwt, verifyJwt, type SigningKey } from './keys';
 import type { OnClientRegistration } from './registration';
 import type {
 	AuthorizationCodeStore,
+	BackchannelAuthStore,
 	ClientAssertionJtiStore,
 	ClientRegistrationTokenStore,
 	DeviceAuthorizationStore,
 	InitialAccessTokenStore,
 	LogoutDeliveryStore,
+	OAuthClient,
 	OAuthClientStore,
 	OidcRefreshTokenStore,
 	PushedAuthorizationRequestStore
@@ -59,6 +61,32 @@ export type OidcProviderConfig<UserType> = {
 	deviceAuthorizationStore?: DeviceAuthorizationStore;
 	deviceCodeTtlMs?: number;
 	devicePollIntervalSeconds?: number;
+	// Optional — enables OIDC Client-Initiated Backchannel Authentication (CIBA Core 1.0).
+	// When set, `/oauth2/bc-authorize` + the `urn:openid:params:grant-type:ciba` token grant
+	// are mounted, `approveBackchannelAuth` / `denyBackchannelAuth` become callable from
+	// your approval UI, and the consumer's `onBackchannelAuthRequest` hook fires so they
+	// can push a notification to the user's second device (FCM / APNs / SMS / etc.).
+	// Poll-mode only in this release; ping + push follow.
+	backchannelAuthStore?: BackchannelAuthStore;
+	backchannelAuthTtlMs?: number;
+	backchannelPollIntervalSeconds?: number;
+	// Resolves the CIBA `login_hint` (RFC's flexible "however you identify the user" param,
+	// e.g. an email, phone, or external id) to the user. Required to enable CIBA. When this
+	// returns `undefined`, /bc-authorize replies with `unknown_user_id`.
+	resolveBackchannelUser?: (
+		hint: { client: OAuthClient; loginHint: string }
+	) => Promise<{ sub: string } | undefined>;
+	// Out-of-band push hook: fires once the auth request is persisted with
+	// `status: 'pending'`. The consumer wires this to their notification backend
+	// (FCM/APNs/Twilio/email) so the user can approve on their phone. The package never
+	// owns this transport — we just hand you the context.
+	onBackchannelAuthRequest?: (context: {
+		authReqId: string;
+		bindingMessage: string | undefined;
+		clientId: string;
+		scopes: string[];
+		userSub: string;
+	}) => Promise<void> | void;
 	// Extra ACCESS token claims (per-token, after grants/exchange). Reserved keys (iss/sub/
 	// aud/exp/iat/jti/client_id/scope/token_use/act/cnf) cannot be overridden.
 	getAccessTokenClaims?: (context: {
@@ -663,6 +691,230 @@ export const exchangeDeviceCode = async <UserType>({
 
 	// Single-use: drop the record before minting so a replay can't double-issue.
 	await config.deviceAuthorizationStore.deleteByDeviceCodeHash(deviceCodeHash);
+	const tokenSet = await issueTokenSet({
+		clientId,
+		config,
+		dpopJkt,
+		now,
+		scopes: record.scopes,
+		sub: record.userSub
+	});
+
+	return { ...tokenSet, ok: true };
+};
+
+// OIDC Client-Initiated Backchannel Authentication (CIBA Core 1.0). The desktop / web
+// client hits /oauth2/bc-authorize with a `login_hint` for the user; the package resolves
+// the hint via `resolveBackchannelUser`, persists a pending request, and fires
+// `onBackchannelAuthRequest` so the consumer can push a notification to the user's phone.
+// The user approves on the phone (consumer calls `approveBackchannelAuth`), and the
+// client polls /oauth2/token with `grant_type=urn:openid:params:grant-type:ciba` to
+// collect the tokens. Banking + healthcare + B2B-internal workflow.
+const AUTH_REQ_ID_BYTES = 32;
+const DEFAULT_BACKCHANNEL_TTL_MINUTES = 10;
+const DEFAULT_BACKCHANNEL_TTL_MS =
+	MILLISECONDS_IN_A_MINUTE * DEFAULT_BACKCHANNEL_TTL_MINUTES;
+const DEFAULT_BACKCHANNEL_POLL_INTERVAL_SECONDS = 5;
+export const CIBA_GRANT_TYPE = 'urn:openid:params:grant-type:ciba';
+
+export type BackchannelAuthResponse = {
+	auth_req_id: string;
+	expires_in: number;
+	interval: number;
+};
+
+export type BackchannelAuthError =
+	| 'expired_login_hint_token'
+	| 'invalid_client'
+	| 'invalid_request'
+	| 'unknown_user_id';
+
+export const issueBackchannelAuth = async <UserType>({
+	clientId,
+	config,
+	loginHint,
+	bindingMessage,
+	now = Date.now(),
+	requestedScopes
+}: {
+	clientId: string;
+	config: OidcProviderConfig<UserType>;
+	loginHint: string;
+	bindingMessage?: string;
+	now?: number;
+	requestedScopes: string[];
+}): Promise<
+	| { error: BackchannelAuthError; ok: false }
+	| ({ ok: true } & BackchannelAuthResponse)
+> => {
+	if (!config.backchannelAuthStore || !config.resolveBackchannelUser) {
+		return { error: 'invalid_request', ok: false };
+	}
+	const client = await config.clientStore.findClient(clientId);
+	if (!client) return { error: 'invalid_client', ok: false };
+	const resolved = await config.resolveBackchannelUser({
+		client,
+		loginHint
+	});
+	if (!resolved) return { error: 'unknown_user_id', ok: false };
+
+	const authReqId = generateSecureToken(AUTH_REQ_ID_BYTES);
+	const ttl = config.backchannelAuthTtlMs ?? DEFAULT_BACKCHANNEL_TTL_MS;
+	const interval =
+		config.backchannelPollIntervalSeconds ??
+		DEFAULT_BACKCHANNEL_POLL_INTERVAL_SECONDS;
+
+	await config.backchannelAuthStore.saveBackchannelAuth({
+		authReqId,
+		bindingMessage,
+		clientId,
+		createdAt: now,
+		expiresAt: now + ttl,
+		intervalSeconds: interval,
+		scopes: requestedScopes,
+		status: 'pending',
+		userSub: resolved.sub
+	});
+
+	await config.onBackchannelAuthRequest?.({
+		authReqId,
+		bindingMessage,
+		clientId,
+		scopes: requestedScopes,
+		userSub: resolved.sub
+	});
+
+	return {
+		auth_req_id: authReqId,
+		expires_in: Math.floor(ttl / MS_PER_SECOND),
+		interval,
+		ok: true
+	};
+};
+
+export type BackchannelDecisionResult =
+	| {
+			error:
+				| 'already_decided'
+				| 'expired_token'
+				| 'invalid_auth_req_id'
+				| 'not_configured';
+			ok: false;
+	  }
+	| { ok: true };
+
+const decideBackchannel = async <UserType>(
+	config: OidcProviderConfig<UserType>,
+	authReqId: string,
+	approval: { status: 'approved' | 'denied'; userSub?: string }
+): Promise<BackchannelDecisionResult> => {
+	if (!config.backchannelAuthStore) {
+		return { error: 'not_configured', ok: false };
+	}
+	const record =
+		await config.backchannelAuthStore.findByAuthReqId(authReqId);
+	if (!record) return { error: 'invalid_auth_req_id', ok: false };
+	if (record.expiresAt < Date.now()) {
+		return { error: 'expired_token', ok: false };
+	}
+	if (record.status !== 'pending') {
+		return { error: 'already_decided', ok: false };
+	}
+	await config.backchannelAuthStore.updateStatus(
+		authReqId,
+		approval.status,
+		approval.userSub ?? record.userSub
+	);
+
+	return { ok: true };
+};
+
+export const approveBackchannelAuth = async <UserType>({
+	authReqId,
+	config,
+	userSub
+}: {
+	authReqId: string;
+	config: OidcProviderConfig<UserType>;
+	userSub?: string;
+}) =>
+	decideBackchannel(config, authReqId, {
+		status: 'approved',
+		userSub
+	});
+
+export const denyBackchannelAuth = async <UserType>({
+	authReqId,
+	config
+}: {
+	authReqId: string;
+	config: OidcProviderConfig<UserType>;
+}) => decideBackchannel(config, authReqId, { status: 'denied' });
+
+export type BackchannelExchangeError =
+	| 'access_denied'
+	| 'authorization_pending'
+	| 'expired_token'
+	| 'invalid_grant'
+	| 'slow_down';
+
+export type BackchannelExchangeResult =
+	| {
+			access_token: string;
+			expires_in: number;
+			id_token: string;
+			ok: true;
+			refresh_token: string;
+			scope: string;
+			token_type: 'Bearer' | 'DPoP';
+	  }
+	| { error: BackchannelExchangeError; ok: false };
+
+export const exchangeBackchannelAuth = async <UserType>({
+	authReqId,
+	clientId,
+	config,
+	dpopJkt,
+	now = Date.now()
+}: {
+	authReqId: string;
+	clientId: string;
+	config: OidcProviderConfig<UserType>;
+	dpopJkt?: string;
+	now?: number;
+}): Promise<BackchannelExchangeResult> => {
+	if (!config.backchannelAuthStore) {
+		return { error: 'invalid_grant', ok: false };
+	}
+	const record =
+		await config.backchannelAuthStore.findByAuthReqId(authReqId);
+	if (!record || record.clientId !== clientId) {
+		return { error: 'invalid_grant', ok: false };
+	}
+	if (record.expiresAt < now) {
+		await config.backchannelAuthStore.deleteByAuthReqId(authReqId);
+
+		return { error: 'expired_token', ok: false };
+	}
+	// Poll-rate enforcement: if the client polls faster than `intervalSeconds` since
+	// its last poll, bump the interval and return slow_down per spec.
+	if (
+		record.lastPolledAt !== undefined &&
+		now - record.lastPolledAt < record.intervalSeconds * MS_PER_SECOND
+	) {
+		return { error: 'slow_down', ok: false };
+	}
+	await config.backchannelAuthStore.recordPoll(authReqId, now);
+
+	if (record.status === 'pending') {
+		return { error: 'authorization_pending', ok: false };
+	}
+	if (record.status === 'denied' || record.userSub === undefined) {
+		return { error: 'access_denied', ok: false };
+	}
+
+	// Single-use: drop the record before minting so a replay can't double-issue.
+	await config.backchannelAuthStore.deleteByAuthReqId(authReqId);
 	const tokenSet = await issueTokenSet({
 		clientId,
 		config,

--- a/src/oidc/inMemoryStores.ts
+++ b/src/oidc/inMemoryStores.ts
@@ -1,6 +1,8 @@
 import type {
 	AuthorizationCode,
 	AuthorizationCodeStore,
+	BackchannelAuthRequest,
+	BackchannelAuthStore,
 	ClientAssertionJtiStore,
 	ClientRegistrationToken,
 	ClientRegistrationTokenStore,
@@ -35,6 +37,29 @@ export const createInMemoryAuthorizationCodeStore =
 			}
 		};
 	};
+export const createInMemoryBackchannelAuthStore = (): BackchannelAuthStore => {
+	const byAuthReqId = new Map<string, BackchannelAuthRequest>();
+
+	return {
+		deleteByAuthReqId: async (authReqId) => {
+			byAuthReqId.delete(authReqId);
+		},
+		findByAuthReqId: async (authReqId) => byAuthReqId.get(authReqId),
+		recordPoll: async (authReqId, polledAt) => {
+			const record = byAuthReqId.get(authReqId);
+			if (!record) return;
+			byAuthReqId.set(authReqId, { ...record, lastPolledAt: polledAt });
+		},
+		saveBackchannelAuth: async (request) => {
+			byAuthReqId.set(request.authReqId, { ...request });
+		},
+		updateStatus: async (authReqId, status, userSub) => {
+			const record = byAuthReqId.get(authReqId);
+			if (!record) return;
+			byAuthReqId.set(authReqId, { ...record, status, userSub });
+		}
+	};
+};
 export const createInMemoryClientAssertionJtiStore =
 	(): ClientAssertionJtiStore => {
 		const seen = new Map<string, number>();

--- a/src/oidc/postgresStores.ts
+++ b/src/oidc/postgresStores.ts
@@ -11,6 +11,9 @@ import { type AnyPgDatabase, createNeonDatabase } from '../stores/postgres';
 import type {
 	AuthorizationCode,
 	AuthorizationCodeStore,
+	BackchannelAuthRequest,
+	BackchannelAuthStatus,
+	BackchannelAuthStore,
 	ClientAssertionJtiStore,
 	ClientRegistrationToken,
 	ClientRegistrationTokenStore,
@@ -33,6 +36,23 @@ const DEFAULT_LIST_LIMIT = 100;
 
 const ID_LENGTH = 255;
 
+export const oauthBackchannelAuthRequestsTable = pgTable(
+	'auth_oauth_backchannel_auth_requests',
+	{
+		auth_req_id: varchar('auth_req_id', { length: ID_LENGTH }).primaryKey(),
+		binding_message: text('binding_message'),
+		client_id: varchar('client_id', { length: ID_LENGTH }).notNull(),
+		created_at_ms: bigint('created_at_ms', { mode: 'number' }).notNull(),
+		expires_at_ms: bigint('expires_at_ms', { mode: 'number' }).notNull(),
+		interval_seconds: bigint('interval_seconds', {
+			mode: 'number'
+		}).notNull(),
+		last_polled_at_ms: bigint('last_polled_at_ms', { mode: 'number' }),
+		scopes: text('scopes').array().notNull(),
+		status: varchar('status', { length: 16 }).notNull(),
+		user_sub: varchar('user_sub', { length: ID_LENGTH })
+	}
+);
 export const oauthClientAssertionJtisTable = pgTable(
 	'auth_oauth_client_assertion_jtis',
 	{
@@ -44,7 +64,6 @@ export const oauthClientAssertionJtisTable = pgTable(
 		jti: varchar('jti', { length: ID_LENGTH }).notNull()
 	}
 );
-
 export const oauthClientRegistrationTokensTable = pgTable(
 	'auth_oauth_client_registration_tokens',
 	{
@@ -53,7 +72,6 @@ export const oauthClientRegistrationTokensTable = pgTable(
 		token_hash: varchar('token_hash', { length: ID_LENGTH }).primaryKey()
 	}
 );
-
 export const oauthClientsTable = pgTable('auth_oauth_clients', {
 	backchannel_logout_uri: varchar('backchannel_logout_uri', {
 		length: URL_LENGTH
@@ -71,7 +89,6 @@ export const oauthClientsTable = pgTable('auth_oauth_clients', {
 	require_signed_request_object: boolean('require_signed_request_object'),
 	scopes: text('scopes').array().notNull()
 });
-
 export const oauthCodesTable = pgTable('auth_oauth_codes', {
 	acr: varchar('acr', { length: ID_LENGTH }),
 	claims_json: jsonb('claims_json').$type<Record<string, unknown>>(),
@@ -86,7 +103,6 @@ export const oauthCodesTable = pgTable('auth_oauth_codes', {
 	scopes: text('scopes').array().notNull(),
 	user_id: varchar('user_id', { length: ID_LENGTH }).notNull()
 });
-
 export const oauthDeviceAuthorizationsTable = pgTable(
 	'auth_oauth_device_authorizations',
 	{
@@ -103,14 +119,12 @@ export const oauthDeviceAuthorizationsTable = pgTable(
 		user_sub: varchar('user_sub', { length: ID_LENGTH })
 	}
 );
-
 export const oauthInitialAccessTokensTable = pgTable(
 	'auth_oauth_initial_access_tokens',
 	{
 		token_hash: varchar('token_hash', { length: ID_LENGTH }).primaryKey()
 	}
 );
-
 export const oauthLogoutDeliveriesTable = pgTable(
 	'auth_oauth_logout_deliveries',
 	{
@@ -125,7 +139,6 @@ export const oauthLogoutDeliveriesTable = pgTable(
 		user_id: varchar('user_id', { length: ID_LENGTH }).notNull()
 	}
 );
-
 export const oauthPushedAuthorizationRequestsTable = pgTable(
 	'auth_oauth_pushed_authorization_requests',
 	{
@@ -140,7 +153,6 @@ export const oauthPushedAuthorizationRequestsTable = pgTable(
 		}).primaryKey()
 	}
 );
-
 export const oauthRefreshTokensTable = pgTable('auth_oauth_refresh_tokens', {
 	acr: varchar('acr', { length: ID_LENGTH }),
 	claims_json: jsonb('claims_json').$type<Record<string, unknown>>(),
@@ -586,5 +598,77 @@ export const createPostgresPushedAuthorizationRequestStore = (
 			params_json: request.params,
 			request_uri_hash: request.requestUriHash
 		});
+	}
+});
+
+type BackchannelAuthRow = typeof oauthBackchannelAuthRequestsTable.$inferSelect;
+
+const toBackchannelAuth = (row: BackchannelAuthRow): BackchannelAuthRequest => ({
+	authReqId: row.auth_req_id,
+	bindingMessage: row.binding_message ?? undefined,
+	clientId: row.client_id,
+	createdAt: row.created_at_ms,
+	expiresAt: row.expires_at_ms,
+	intervalSeconds: row.interval_seconds,
+	lastPolledAt: row.last_polled_at_ms ?? undefined,
+	scopes: row.scopes,
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- deserialization boundary: status was persisted from BackchannelAuthStatus
+	status: row.status as BackchannelAuthStatus,
+	userSub: row.user_sub ?? undefined
+});
+
+export const createNeonBackchannelAuthStore = (databaseUrl: string) =>
+	createPostgresBackchannelAuthStore(createNeonDatabase(databaseUrl));
+
+export const createPostgresBackchannelAuthStore = (
+	db: AnyPgDatabase
+): BackchannelAuthStore => ({
+	deleteByAuthReqId: async (authReqId) => {
+		await db
+			.delete(oauthBackchannelAuthRequestsTable)
+			.where(
+				eq(oauthBackchannelAuthRequestsTable.auth_req_id, authReqId)
+			);
+	},
+	findByAuthReqId: async (authReqId) => {
+		const [row] = await db
+			.select()
+			.from(oauthBackchannelAuthRequestsTable)
+			.where(
+				eq(oauthBackchannelAuthRequestsTable.auth_req_id, authReqId)
+			)
+			.limit(1);
+
+		return row ? toBackchannelAuth(row) : undefined;
+	},
+	recordPoll: async (authReqId, polledAt) => {
+		await db
+			.update(oauthBackchannelAuthRequestsTable)
+			.set({ last_polled_at_ms: polledAt })
+			.where(
+				eq(oauthBackchannelAuthRequestsTable.auth_req_id, authReqId)
+			);
+	},
+	saveBackchannelAuth: async (request) => {
+		await db.insert(oauthBackchannelAuthRequestsTable).values({
+			auth_req_id: request.authReqId,
+			binding_message: request.bindingMessage ?? null,
+			client_id: request.clientId,
+			created_at_ms: request.createdAt,
+			expires_at_ms: request.expiresAt,
+			interval_seconds: request.intervalSeconds,
+			last_polled_at_ms: request.lastPolledAt ?? null,
+			scopes: request.scopes,
+			status: request.status,
+			user_sub: request.userSub ?? null
+		});
+	},
+	updateStatus: async (authReqId, status, userSub) => {
+		await db
+			.update(oauthBackchannelAuthRequestsTable)
+			.set({ status, user_sub: userSub ?? null })
+			.where(
+				eq(oauthBackchannelAuthRequestsTable.auth_req_id, authReqId)
+			);
 	}
 });

--- a/src/oidc/routes.ts
+++ b/src/oidc/routes.ts
@@ -9,11 +9,14 @@ import type { RouteString } from '../types';
 import { userSessionIdTypebox } from '../typebox';
 import {
 	approveDeviceAuthorization,
+	CIBA_GRANT_TYPE,
 	DEFAULT_OIDC_ROUTE,
 	denyDeviceAuthorization,
+	exchangeBackchannelAuth,
 	exchangeDeviceCode,
 	exchangeToken,
 	introspectToken,
+	issueBackchannelAuth,
 	issueDeviceAuthorization,
 	issueTokenSet,
 	revokeRefreshToken,
@@ -132,6 +135,7 @@ export const oidcProviderRoutes = <UserType>(
 	const introspectRoute: RouteString = `${oidcRoute}/introspect`;
 	const revokeRoute: RouteString = `${oidcRoute}/revoke`;
 	const deviceAuthorizationRoute: RouteString = `${oidcRoute}/device_authorization`;
+	const backchannelAuthorizationRoute: RouteString = `${oidcRoute}/bc-authorize`;
 	const deviceApproveRoute: RouteString = `${oidcRoute}/device/decision`;
 	const endSessionRoute: RouteString = `${oidcRoute}/end_session`;
 	const parRoute: RouteString = `${oidcRoute}/par`;
@@ -373,6 +377,50 @@ export const oidcProviderRoutes = <UserType>(
 		);
 	};
 
+	const grantBackchannel = async (
+		client: OAuthClient,
+		body: Record<string, string | undefined>,
+		dpop: string | undefined
+	) => {
+		if (config.backchannelAuthStore === undefined) {
+			return oauthError(HTTP_BAD_REQUEST, 'unsupported_grant_type');
+		}
+		if (body.auth_req_id === undefined) {
+			return oauthError(HTTP_BAD_REQUEST, 'invalid_request');
+		}
+		const dpopResult =
+			dpop === undefined
+				? undefined
+				: await verifyDpopProof({
+						htm: 'POST',
+						htu: tokenUrl,
+						proof: dpop
+					});
+		if (dpop !== undefined && dpopResult === undefined) {
+			return oauthError(HTTP_BAD_REQUEST, 'invalid_dpop_proof');
+		}
+
+		const result = await exchangeBackchannelAuth({
+			authReqId: body.auth_req_id,
+			clientId: client.clientId,
+			config,
+			dpopJkt: dpopResult?.jkt
+		});
+		if (!result.ok) return oauthError(HTTP_BAD_REQUEST, result.error);
+
+		return jsonResponse(
+			{
+				access_token: result.access_token,
+				expires_in: result.expires_in,
+				id_token: result.id_token,
+				refresh_token: result.refresh_token,
+				scope: result.scope,
+				token_type: dpopResult === undefined ? 'Bearer' : 'DPoP'
+			},
+			HTTP_OK
+		);
+	};
+
 	const grantDeviceCode = async (
 		client: OAuthClient,
 		body: Record<string, string | undefined>,
@@ -425,6 +473,9 @@ export const oidcProviderRoutes = <UserType>(
 	if (config.deviceAuthorizationStore) {
 		grantTypes.push('urn:ietf:params:oauth:grant-type:device_code');
 	}
+	if (config.backchannelAuthStore) {
+		grantTypes.push(CIBA_GRANT_TYPE);
+	}
 
 	const discovery: Record<string, boolean | string | string[]> = {
 		authorization_endpoint: `${issuer}${authorizeRoute}`,
@@ -457,6 +508,12 @@ export const oidcProviderRoutes = <UserType>(
 	};
 	if (config.deviceAuthorizationStore) {
 		discovery.device_authorization_endpoint = `${issuer}${deviceAuthorizationRoute}`;
+	}
+	if (config.backchannelAuthStore) {
+		// OIDC CIBA Core 1.0 §4 discovery metadata.
+		discovery.backchannel_authentication_endpoint = `${issuer}${backchannelAuthorizationRoute}`;
+		discovery.backchannel_token_delivery_modes_supported = ['poll'];
+		discovery.backchannel_user_code_parameter_supported = false;
 	}
 	if (config.clientRegistrationTokenStore !== undefined) {
 		discovery.registration_endpoint = registrationBaseUrl;
@@ -872,12 +929,16 @@ export const oidcProviderRoutes = <UserType>(
 				) {
 					return grantDeviceCode(client, body, headers.dpop);
 				}
+				if (body.grant_type === CIBA_GRANT_TYPE) {
+					return grantBackchannel(client, body, headers.dpop);
+				}
 
 				return oauthError(HTTP_BAD_REQUEST, 'unsupported_grant_type');
 			},
 			{
 				body: t.Object({
 					audience: t.Optional(t.String()),
+					auth_req_id: t.Optional(t.String()),
 					client_assertion: t.Optional(t.String()),
 					client_assertion_type: t.Optional(t.String()),
 					client_id: t.Optional(t.String()),
@@ -1041,6 +1102,69 @@ export const oidcProviderRoutes = <UserType>(
 					client_secret: t.Optional(t.String()),
 					token: t.String(),
 					token_type_hint: t.Optional(t.String())
+				}),
+				headers: t.Object({
+					authorization: t.Optional(t.String())
+				})
+			}
+		)
+		// OIDC CIBA Core 1.0 §7.1 — backchannel authorization request. Clients
+		// hit this with a login_hint identifying the user; the package resolves
+		// the user via `resolveBackchannelUser`, persists a pending auth_req,
+		// fires `onBackchannelAuthRequest` so the consumer can push a notification
+		// to the user's phone, and returns an auth_req_id the client polls
+		// /token with (grant_type=urn:openid:params:grant-type:ciba).
+		.post(
+			backchannelAuthorizationRoute,
+			async ({ body, headers }) => {
+				if (config.backchannelAuthStore === undefined) {
+					return oauthError(HTTP_BAD_REQUEST, 'unsupported_grant_type');
+				}
+				const basic = readBasicAuth(headers.authorization);
+				const clientId = body.client_id ?? basic.clientId;
+				const clientSecret = body.client_secret ?? basic.clientSecret;
+				if (clientId === undefined) {
+					return oauthError(HTTP_UNAUTHORIZED, 'invalid_client');
+				}
+				const client = await authenticateClient(clientId, clientSecret);
+				if (client === undefined) {
+					return oauthError(HTTP_UNAUTHORIZED, 'invalid_client');
+				}
+				if (body.login_hint === undefined) {
+					return oauthError(HTTP_BAD_REQUEST, 'invalid_request');
+				}
+				const requested =
+					body.scope === undefined || body.scope.length === 0
+						? client.scopes
+						: body.scope
+								.split(' ')
+								.filter((entry) => client.scopes.includes(entry));
+				const result = await issueBackchannelAuth({
+					bindingMessage: body.binding_message,
+					clientId: client.clientId,
+					config,
+					loginHint: body.login_hint,
+					now: Date.now(),
+					requestedScopes: requested
+				});
+				if (!result.ok) return oauthError(HTTP_BAD_REQUEST, result.error);
+
+				return jsonResponse(
+					{
+						auth_req_id: result.auth_req_id,
+						expires_in: result.expires_in,
+						interval: result.interval
+					},
+					HTTP_OK
+				);
+			},
+			{
+				body: t.Object({
+					binding_message: t.Optional(t.String()),
+					client_id: t.Optional(t.String()),
+					client_secret: t.Optional(t.String()),
+					login_hint: t.Optional(t.String()),
+					scope: t.Optional(t.String())
 				}),
 				headers: t.Object({
 					authorization: t.Optional(t.String())

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -204,3 +204,43 @@ export type DeviceAuthorizationStore = {
 		userSub?: string
 	) => Promise<void>;
 };
+
+// OIDC Client-Initiated Backchannel Authentication (CIBA Core 1.0). The user authorizes
+// on a second device — desktop client hits `/oauth2/bc-authorize`, server pushes a
+// notification to the user's phone via the consumer's `onBackchannelAuthRequest` hook,
+// user approves; client polls `/oauth2/token` with `grant_type=urn:openid:params:grant-type:ciba`
+// and gets the tokens. Used by banking + healthcare + B2B-internal apps where the device
+// initiating the request isn't where the user authenticates.
+
+export type BackchannelAuthStatus = 'approved' | 'denied' | 'pending';
+
+export type BackchannelAuthRequest = {
+	authReqId: string;
+	bindingMessage?: string;
+	clientId: string;
+	createdAt: number;
+	expiresAt: number;
+	/** Poll-mode interval seconds. Bumped by 5 each time the client polls faster than
+	 *  allowed (returns `slow_down` until the new interval has elapsed). */
+	intervalSeconds: number;
+	lastPolledAt?: number;
+	scopes: string[];
+	status: BackchannelAuthStatus;
+	userSub?: string;
+};
+
+export type BackchannelAuthStore = {
+	deleteByAuthReqId: (authReqId: string) => Promise<void>;
+	findByAuthReqId: (
+		authReqId: string
+	) => Promise<BackchannelAuthRequest | undefined>;
+	recordPoll: (authReqId: string, at: number) => Promise<void>;
+	saveBackchannelAuth: (
+		request: BackchannelAuthRequest
+	) => Promise<void>;
+	updateStatus: (
+		authReqId: string,
+		status: BackchannelAuthStatus,
+		userSub?: string
+	) => Promise<void>;
+};

--- a/tests/ciba.test.ts
+++ b/tests/ciba.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	approveBackchannelAuth,
+	CIBA_GRANT_TYPE,
+	denyBackchannelAuth,
+	exchangeBackchannelAuth,
+	issueBackchannelAuth,
+	type OidcProviderConfig
+} from '../src/oidc/config';
+import {
+	createInMemoryAuthorizationCodeStore,
+	createInMemoryBackchannelAuthStore,
+	createInMemoryOAuthClientStore,
+	createInMemoryOidcRefreshTokenStore
+} from '../src/oidc/inMemoryStores';
+import { generateSigningKey } from '../src/oidc/keys';
+
+// OIDC CIBA Core 1.0 — desktop client kicks off /bc-authorize with a login_hint, server
+// pushes the consumer's approval flow to the user's phone (via onBackchannelAuthRequest),
+// user approves, client polls /token (grant_type=urn:openid:params:grant-type:ciba) and
+// gets tokens. Poll mode only; ping + push come in a follow-up.
+
+type TestUser = { sub: string };
+
+const buildConfig = async (notifications: unknown[]) => {
+	const signingKey = await generateSigningKey();
+
+	const config: OidcProviderConfig<TestUser> = {
+		authorizationCodeStore: createInMemoryAuthorizationCodeStore(),
+		backchannelAuthStore: createInMemoryBackchannelAuthStore(),
+		backchannelPollIntervalSeconds: 1,
+		clientStore: createInMemoryOAuthClientStore([
+			{
+				clientId: 'partner-app',
+				name: 'Partner',
+				redirectUris: ['https://partner.example/cb'],
+				scopes: ['openid', 'profile']
+			}
+		]),
+		issuer: 'https://id.example.com',
+		refreshTokenStore: createInMemoryOidcRefreshTokenStore(),
+		signingKey,
+		getUserId: (user) => user.sub,
+		onBackchannelAuthRequest: (context) => {
+			notifications.push(context);
+		},
+		resolveBackchannelUser: async ({ loginHint }) =>
+			loginHint === 'alice@example.com' ? { sub: 'alice' } : undefined
+	};
+
+	return config;
+};
+
+describe('CIBA', () => {
+	test('issueBackchannelAuth resolves the hint, fires the push hook, and returns auth_req_id', async () => {
+		const notifications: unknown[] = [];
+		const config = await buildConfig(notifications);
+
+		const result = await issueBackchannelAuth({
+			bindingMessage: 'ACME-1234',
+			clientId: 'partner-app',
+			config,
+			loginHint: 'alice@example.com',
+			requestedScopes: ['openid', 'profile']
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error('unreachable');
+		expect(result.auth_req_id.length).toBeGreaterThan(0);
+		expect(result.expires_in).toBeGreaterThan(0);
+		expect(notifications).toHaveLength(1);
+		expect(notifications[0]).toMatchObject({
+			authReqId: result.auth_req_id,
+			bindingMessage: 'ACME-1234',
+			clientId: 'partner-app',
+			scopes: ['openid', 'profile'],
+			userSub: 'alice'
+		});
+	});
+
+	test('unknown login_hint returns unknown_user_id', async () => {
+		const config = await buildConfig([]);
+		const result = await issueBackchannelAuth({
+			clientId: 'partner-app',
+			config,
+			loginHint: 'unknown@example.com',
+			requestedScopes: ['openid']
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error('unreachable');
+		expect(result.error).toBe('unknown_user_id');
+	});
+
+	test('polling a pending auth returns authorization_pending; after approve returns tokens', async () => {
+		const config = await buildConfig([]);
+		const issued = await issueBackchannelAuth({
+			clientId: 'partner-app',
+			config,
+			loginHint: 'alice@example.com',
+			requestedScopes: ['openid']
+		});
+		if (!issued.ok) throw new Error('unreachable');
+
+		const pending = await exchangeBackchannelAuth({
+			authReqId: issued.auth_req_id,
+			clientId: 'partner-app',
+			config
+		});
+		expect(pending.ok).toBe(false);
+		if (pending.ok) throw new Error('unreachable');
+		expect(pending.error).toBe('authorization_pending');
+
+		const approval = await approveBackchannelAuth({
+			authReqId: issued.auth_req_id,
+			config
+		});
+		expect(approval.ok).toBe(true);
+
+		// Sleep past the per-poll interval (1s in this test config) so we don't trip slow_down.
+		// eslint-disable-next-line promise/avoid-new -- short scheduler sleep to clear the poll-rate gate the previous exchange call recorded
+		await new Promise<void>((resolve) => setTimeout(resolve, 1100));
+
+		const tokens = await exchangeBackchannelAuth({
+			authReqId: issued.auth_req_id,
+			clientId: 'partner-app',
+			config
+		});
+		expect(tokens.ok).toBe(true);
+		if (!tokens.ok) throw new Error('unreachable');
+		expect(tokens.access_token.length).toBeGreaterThan(0);
+		expect(tokens.id_token.length).toBeGreaterThan(0);
+		expect(tokens.refresh_token.length).toBeGreaterThan(0);
+		expect(tokens.scope).toBe('openid');
+	});
+
+	test('denied auth returns access_denied at exchange', async () => {
+		const config = await buildConfig([]);
+		const issued = await issueBackchannelAuth({
+			clientId: 'partner-app',
+			config,
+			loginHint: 'alice@example.com',
+			requestedScopes: ['openid']
+		});
+		if (!issued.ok) throw new Error('unreachable');
+
+		await denyBackchannelAuth({ authReqId: issued.auth_req_id, config });
+
+		const result = await exchangeBackchannelAuth({
+			authReqId: issued.auth_req_id,
+			clientId: 'partner-app',
+			config
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error('unreachable');
+		expect(result.error).toBe('access_denied');
+	});
+
+	test('polling faster than interval returns slow_down', async () => {
+		const config = await buildConfig([]);
+		const issued = await issueBackchannelAuth({
+			clientId: 'partner-app',
+			config,
+			loginHint: 'alice@example.com',
+			requestedScopes: ['openid']
+		});
+		if (!issued.ok) throw new Error('unreachable');
+
+		const first = await exchangeBackchannelAuth({
+			authReqId: issued.auth_req_id,
+			clientId: 'partner-app',
+			config
+		});
+		expect(first.ok).toBe(false);
+		if (first.ok) throw new Error('unreachable');
+		// First poll succeeds (returns pending) and records the timestamp; immediate second
+		// poll should slow_down.
+		const second = await exchangeBackchannelAuth({
+			authReqId: issued.auth_req_id,
+			clientId: 'partner-app',
+			config
+		});
+		expect(second.ok).toBe(false);
+		if (second.ok) throw new Error('unreachable');
+		expect(second.error).toBe('slow_down');
+	});
+
+	test('grant type constant matches the spec value', () => {
+		expect(CIBA_GRANT_TYPE).toBe('urn:openid:params:grant-type:ciba');
+	});
+});


### PR DESCRIPTION
First half of the 0.36.0 cycle. G4 (mTLS client auth) ships next + the cycle promotes to stable 0.36.0 — together they unlock the FAPI 2.0 baseline.

## What it does
OIDC Client-Initiated Backchannel Authentication (CIBA Core 1.0) poll-mode flow. Desktop / web client kicks off /bc-authorize with a login_hint; package resolves the hint, persists a pending request, fires `onBackchannelAuthRequest` so the consumer can push a notification to the user's phone; user approves; client polls /token with `grant_type=urn:openid:params:grant-type:ciba` and gets the tokens.

## Endpoints
- `POST {oidcRoute}/bc-authorize` — initiate (same client auth as /token)
- `POST {oidcRoute}/token` extended with the ciba grant

## Discovery
- `backchannel_authentication_endpoint`
- `backchannel_token_delivery_modes_supported: ['poll']`
- `backchannel_user_code_parameter_supported: false`
- `grant_types_supported` += CIBA grant

## Architecture
- `BackchannelAuthStore` interface + in-memory and Neon/Postgres impls
- New `oauth_backchannel_auth_requests` table; auto-included in the 0.35.0 `absolute-auth migrate` CLI's oidc block
- Poll-rate enforcement (slow_down returned for too-fast polls)
- Single-use (approve + first exchange drops the record)

## Out of scope this beta
Ping + push delivery modes (more infra); login_hint_token + id_token_hint variants (login_hint only for v1); user_code parameter (deliberately off per FAPI).

## Tests
6 new in `tests/ciba.test.ts` — issue + unknown hint + pending→approve→tokens + deny + slow_down + grant-type constant.

**368 / 368 tests pass.** Typecheck + lint clean.