### PR TITLE
0.37.0 — passkey composables + background ops

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@eslint/js": "^10.0.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^2.7.1",
+        "@simplewebauthn/browser": "^13.3.0",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/bun": "1.2.9",
         "@types/react": "^19.0.0",
@@ -33,6 +34,8 @@
         "vue": "^3.5.34",
       },
       "peerDependencies": {
+        "@opentelemetry/api": ">=1.7",
+        "@simplewebauthn/browser": ">=13",
         "elysia": ">= 1.4.26",
         "react": ">=18 <20",
         "solid-js": ">=1.8",
@@ -40,6 +43,8 @@
         "vue": ">=3.4",
       },
       "optionalPeers": [
+        "@opentelemetry/api",
+        "@simplewebauthn/browser",
         "react",
         "solid-js",
         "svelte",
@@ -121,6 +126,8 @@
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@petamoriken/float16": ["@petamoriken/float16@3.9.2", "", {}, "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.36.0",
+	"version": "0.37.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {
@@ -32,6 +32,7 @@
 	"types": "./dist/index.d.ts",
 	"peerDependencies": {
 		"@opentelemetry/api": ">=1.7",
+		"@simplewebauthn/browser": ">=13",
 		"elysia": ">= 1.4.26",
 		"react": ">=18 <20",
 		"solid-js": ">=1.8",
@@ -40,6 +41,9 @@
 	},
 	"peerDependenciesMeta": {
 		"@opentelemetry/api": {
+			"optional": true
+		},
+		"@simplewebauthn/browser": {
 			"optional": true
 		},
 		"react": {
@@ -66,6 +70,7 @@
 		"@eslint/js": "^10.0.1",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/sdk-trace-base": "^2.7.1",
+		"@simplewebauthn/browser": "^13.3.0",
 		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/bun": "1.2.9",
 		"@types/react": "^19.0.0",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,1 +1,5 @@
 export * from './createAuthClient';
+export {
+	runConditionalAuthentication,
+	runPasskeyRegistration
+} from './passkeyHelpers';

--- a/src/client/passkeyHelpers.ts
+++ b/src/client/passkeyHelpers.ts
@@ -1,0 +1,87 @@
+// Framework-agnostic glue between the WebAuthn ceremonies the package exposes via
+// `createAuthClient` and the browser's `navigator.credentials.{get,create}` APIs.
+// Used by the framework composables (`./react`, `./vue`, `./solid`, `./svelte`) so the
+// React + Vue + Solid + Svelte hooks all share the same imperative core; the framework
+// wrappers only add reactivity.
+//
+// `@simplewebauthn/browser` is an OPTIONAL peer dep — consumers that don't import any
+// of the passkey composables never load it. We dynamic-import lazily on first call so a
+// non-passkey consumer pays nothing at module load.
+
+import type { AuthClient, AuthClientError } from './createAuthClient';
+
+type StartAuthentication = (options: {
+	optionsJSON: unknown;
+	useBrowserAutofill?: boolean;
+}) => Promise<unknown>;
+
+type StartRegistration = (options: {
+	optionsJSON: unknown;
+}) => Promise<unknown>;
+
+const loadBrowser = async () => {
+	const mod: { startAuthentication: StartAuthentication; startRegistration: StartRegistration } =
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- @simplewebauthn/browser is an optional peer dep; the dynamic import is gated by composable use sites + the shape matches the upstream signature we depend on
+		(await import('@simplewebauthn/browser')) as {
+			startAuthentication: StartAuthentication;
+			startRegistration: StartRegistration;
+		};
+
+	return mod;
+};
+
+const errorFor = (caught: unknown): AuthClientError => ({
+	body: null,
+	message: caught instanceof Error ? caught.message : 'webauthn_failed',
+	status: 0
+});
+
+// Runs the WebAuthn authentication ceremony in conditional-UI mode (the browser surfaces
+// saved passkeys directly via autofill on a focused `<input autocomplete="webauthn">`).
+// Returns the same `{ data, error }` shape `createAuthClient` already uses, so composables
+// can pipe the result into their state setters unchanged.
+export const runConditionalAuthentication = async (client: AuthClient) => {
+	if (typeof window === 'undefined' || !window.PublicKeyCredential) {
+		return {
+			data: null,
+			error: errorFor(new Error('webauthn_unavailable'))
+		};
+	}
+	const options = await client.passkeys.authenticateOptions();
+	if (options.error) return { data: null, error: options.error };
+	try {
+		const { startAuthentication } = await loadBrowser();
+		const credential = await startAuthentication({
+			optionsJSON: options.data,
+			useBrowserAutofill: true
+		});
+
+		return client.passkeys.authenticateVerify(credential);
+	} catch (caught) {
+		return { data: null, error: errorFor(caught) };
+	}
+};
+
+// Runs the WebAuthn registration ceremony for the currently authenticated user. Used by
+// the "upgrade to passkey" prompt — after a password sign-in, surface a "save a passkey
+// to this device for next time?" CTA.
+export const runPasskeyRegistration = async (client: AuthClient) => {
+	if (typeof window === 'undefined' || !window.PublicKeyCredential) {
+		return {
+			data: null,
+			error: errorFor(new Error('webauthn_unavailable'))
+		};
+	}
+	const options = await client.passkeys.registerOptions();
+	if (options.error) return { data: null, error: options.error };
+	try {
+		const { startRegistration } = await loadBrowser();
+		const credential = await startRegistration({
+			optionsJSON: options.data
+		});
+
+		return client.passkeys.registerVerify(credential);
+	} catch (caught) {
+		return { data: null, error: errorFor(caught) };
+	}
+};

--- a/src/client/react.ts
+++ b/src/client/react.ts
@@ -4,6 +4,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AuthClient, AuthClientError } from './createAuthClient';
+import {
+	runConditionalAuthentication,
+	runPasskeyRegistration
+} from './passkeyHelpers';
 
 type Mutator<Args, Data> = (
 	args: Args
@@ -60,6 +64,87 @@ const useMutation = <Args, Data>(
 
 export const useMagicLink = (client: AuthClient) =>
 	useMutation(client.passwordless.requestMagicLink);
+
+// Conditional-UI WebAuthn ("passkey autofill"). Mount once on the sign-in page with an
+// `<input autocomplete="username webauthn" />` and call `start()` in an effect; the
+// browser surfaces saved passkeys directly in the autofill dropdown. The result feeds
+// the same authenticate-verify route the click-driven flow uses. `cancel()` aborts an
+// in-flight ceremony (e.g. when the user clicks the password tab).
+export const usePasskeyAutofill = (client: AuthClient) => {
+	const [data, setData] = useState<{ status: 'authenticated' } | null>(null);
+	const [error, setError] = useState<AuthClientError | null>(null);
+	const [isPending, setIsPending] = useState(false);
+	const mountedRef = useRef(true);
+	useEffect(
+		() => () => {
+			mountedRef.current = false;
+		},
+		[]
+	);
+
+	const start = useCallback(async () => {
+		setIsPending(true);
+		setError(null);
+		const result = await runConditionalAuthentication(client);
+		if (mountedRef.current) {
+			setData(result.data);
+			setError(result.error);
+			setIsPending(false);
+		}
+	}, [client]);
+
+	const cancel = useCallback(() => {
+		// startAuthentication doesn't expose an AbortController in @simplewebauthn/browser;
+		// best-effort cancel is to clear the pending flag. The Promise will still resolve
+		// when the browser autofill dismisses; mountedRef gates the result write.
+		setIsPending(false);
+	}, []);
+
+	return { cancel, data, error, isPending, start };
+};
+
+// "Upgrade to passkey" prompt — query whether the signed-in user has registered any
+// passkeys yet; surface `shouldPrompt: true` when they don't, plus a `register()` that
+// runs the registration ceremony and refetches the list. Wire `shouldPrompt` to your CTA
+// component so password users see "save a passkey to this device for next time?" after
+// they sign in.
+export const useUpgradeToPasskey = (client: AuthClient) => {
+	const [passkeys, setPasskeys] = useState<unknown[] | null>(null);
+	const [error, setError] = useState<AuthClientError | null>(null);
+	const [isPending, setIsPending] = useState(true);
+	const mountedRef = useRef(true);
+	useEffect(
+		() => () => {
+			mountedRef.current = false;
+		},
+		[]
+	);
+
+	const refetch = useCallback(async () => {
+		setIsPending(true);
+		const result = await client.passkeys.list();
+		if (mountedRef.current) {
+			setPasskeys(result.data);
+			setError(result.error);
+			setIsPending(false);
+		}
+	}, [client]);
+
+	useEffect(() => {
+		void refetch();
+	}, [refetch]);
+
+	const register = useCallback(async () => {
+		const result = await runPasskeyRegistration(client);
+		if (result.error === null) await refetch();
+
+		return result;
+	}, [client, refetch]);
+
+	const shouldPrompt = passkeys !== null && passkeys.length === 0;
+
+	return { error, isPending, passkeys, refetch, register, shouldPrompt };
+};
 
 export const useMfaChallenge = (client: AuthClient) =>
 	useMutation(client.mfa.challenge);

--- a/src/client/solid.ts
+++ b/src/client/solid.ts
@@ -4,6 +4,10 @@
 
 import { createSignal, onCleanup, type Accessor } from 'solid-js';
 import type { AuthClient, AuthClientError } from './createAuthClient';
+import {
+	runConditionalAuthentication,
+	runPasskeyRegistration
+} from './passkeyHelpers';
 
 type Mutator<Args, Data> = (
 	args: Args
@@ -56,6 +60,73 @@ const useMutation = <Args, Data>(
 
 export const useMagicLink = (client: AuthClient) =>
 	useMutation(client.passwordless.requestMagicLink);
+
+// Conditional-UI WebAuthn — see the React doc for the wire-up pattern.
+export const usePasskeyAutofill = (client: AuthClient) => {
+	const [data, setData] = createSignal<{ status: 'authenticated' } | null>(
+		null
+	);
+	const [error, setError] = createSignal<AuthClientError | null>(null);
+	const [isPending, setIsPending] = createSignal(false);
+	let alive = true;
+	onCleanup(() => {
+		alive = false;
+	});
+
+	const start = async () => {
+		setIsPending(true);
+		setError(null);
+		const result = await runConditionalAuthentication(client);
+		if (alive) {
+			setData(() => result.data);
+			setError(result.error);
+			setIsPending(false);
+		}
+	};
+
+	const cancel = () => {
+		setIsPending(false);
+	};
+
+	return { cancel, data, error, isPending, start };
+};
+
+// "Upgrade to passkey" prompt — see the React doc.
+export const useUpgradeToPasskey = (client: AuthClient) => {
+	const [passkeys, setPasskeys] = createSignal<unknown[] | null>(null);
+	const [error, setError] = createSignal<AuthClientError | null>(null);
+	const [isPending, setIsPending] = createSignal(true);
+	let alive = true;
+	onCleanup(() => {
+		alive = false;
+	});
+
+	const refetch = async () => {
+		setIsPending(true);
+		const result = await client.passkeys.list();
+		if (alive) {
+			setPasskeys(() => result.data);
+			setError(result.error);
+			setIsPending(false);
+		}
+	};
+
+	const register = async () => {
+		const result = await runPasskeyRegistration(client);
+		if (result.error === null) await refetch();
+
+		return result;
+	};
+
+	void refetch();
+	const shouldPrompt = () => {
+		const list = passkeys();
+
+		return list !== null && list.length === 0;
+	};
+
+	return { error, isPending, passkeys, refetch, register, shouldPrompt };
+};
 
 export const useMfaChallenge = (client: AuthClient) =>
 	useMutation(client.mfa.challenge);

--- a/src/client/svelte.ts
+++ b/src/client/svelte.ts
@@ -6,6 +6,10 @@
 
 import { writable, type Writable } from 'svelte/store';
 import type { AuthClient, AuthClientError } from './createAuthClient';
+import {
+	runConditionalAuthentication,
+	runPasskeyRegistration
+} from './passkeyHelpers';
 
 type Mutator<Args, Data> = (
 	args: Args
@@ -50,6 +54,60 @@ const useMutation = <Args, Data>(
 
 export const useMagicLink = (client: AuthClient) =>
 	useMutation(client.passwordless.requestMagicLink);
+
+// Conditional-UI WebAuthn — see the React doc for the wire-up pattern.
+export const usePasskeyAutofill = (client: AuthClient) => {
+	const data: Writable<{ status: 'authenticated' } | null> = writable(null);
+	const error: Writable<AuthClientError | null> = writable(null);
+	const isPending = writable(false);
+
+	const start = async () => {
+		isPending.set(true);
+		error.set(null);
+		const result = await runConditionalAuthentication(client);
+		data.set(result.data);
+		error.set(result.error);
+		isPending.set(false);
+	};
+
+	const cancel = () => {
+		isPending.set(false);
+	};
+
+	return { cancel, data, error, isPending, start };
+};
+
+// "Upgrade to passkey" prompt — see the React doc.
+export const useUpgradeToPasskey = (client: AuthClient) => {
+	const passkeys: Writable<unknown[] | null> = writable(null);
+	const error: Writable<AuthClientError | null> = writable(null);
+	const isPending = writable(true);
+	const shouldPrompt = writable(false);
+
+	const recompute = (list: unknown[] | null) => {
+		shouldPrompt.set(list !== null && list.length === 0);
+	};
+
+	const refetch = async () => {
+		isPending.set(true);
+		const result = await client.passkeys.list();
+		passkeys.set(result.data);
+		error.set(result.error);
+		isPending.set(false);
+		recompute(result.data);
+	};
+
+	const register = async () => {
+		const result = await runPasskeyRegistration(client);
+		if (result.error === null) await refetch();
+
+		return result;
+	};
+
+	void refetch();
+
+	return { error, isPending, passkeys, refetch, register, shouldPrompt };
+};
 
 export const useMfaChallenge = (client: AuthClient) =>
 	useMutation(client.mfa.challenge);

--- a/src/client/vue.ts
+++ b/src/client/vue.ts
@@ -4,6 +4,10 @@
 
 import { onScopeDispose, ref, type Ref } from 'vue';
 import type { AuthClient, AuthClientError } from './createAuthClient';
+import {
+	runConditionalAuthentication,
+	runPasskeyRegistration
+} from './passkeyHelpers';
 
 type Mutator<Args, Data> = (
 	args: Args
@@ -54,6 +58,90 @@ const useMutation = <Args, Data>(
 
 export const useMagicLink = (client: AuthClient) =>
 	useMutation(client.passwordless.requestMagicLink);
+
+// Conditional-UI WebAuthn — see the React doc for the wire-up pattern. Returns refs you
+// `v-bind` into your sign-in template; `start()` kicks off the browser-autofill ceremony.
+export const usePasskeyAutofill = (client: AuthClient) => {
+	const data: Ref<{ status: 'authenticated' } | null> = ref(null);
+	const error: Ref<AuthClientError | null> = ref(null);
+	const isPending = ref(false);
+	let alive = true;
+	onScopeDispose(() => {
+		alive = false;
+	});
+
+	const start = async () => {
+		isPending.value = true;
+		error.value = null;
+		const result = await runConditionalAuthentication(client);
+		if (alive) {
+			data.value = result.data;
+			error.value = result.error;
+			isPending.value = false;
+		}
+	};
+
+	const cancel = () => {
+		isPending.value = false;
+	};
+
+	return { cancel, data, error, isPending, start };
+};
+
+// "Upgrade to passkey" prompt — see the React doc. `shouldPrompt` is a computed-style ref
+// that's true when the signed-in user has no passkeys yet.
+export const useUpgradeToPasskey = (client: AuthClient) => {
+	const passkeys: Ref<unknown[] | null> = ref(null);
+	const error: Ref<AuthClientError | null> = ref(null);
+	const isPending = ref(true);
+	let alive = true;
+	onScopeDispose(() => {
+		alive = false;
+	});
+
+	const refetch = async () => {
+		isPending.value = true;
+		const result = await client.passkeys.list();
+		if (alive) {
+			passkeys.value = result.data;
+			error.value = result.error;
+			isPending.value = false;
+		}
+	};
+
+	const register = async () => {
+		const result = await runPasskeyRegistration(client);
+		if (result.error === null) await refetch();
+
+		return result;
+	};
+
+	void refetch();
+	const shouldPrompt = ref(false);
+	const updateShouldPrompt = () => {
+		shouldPrompt.value = passkeys.value !== null && passkeys.value.length === 0;
+	};
+	// Update shouldPrompt whenever the list changes via refetch/register.
+	const wrappedRefetch = async () => {
+		await refetch();
+		updateShouldPrompt();
+	};
+	const wrappedRegister = async () => {
+		const result = await register();
+		updateShouldPrompt();
+
+		return result;
+	};
+
+	return {
+		error,
+		isPending,
+		passkeys,
+		refetch: wrappedRefetch,
+		register: wrappedRegister,
+		shouldPrompt
+	};
+};
 
 export const useMfaChallenge = (client: AuthClient) =>
 	useMutation(client.mfa.challenge);

--- a/src/credentials/backgroundOps.ts
+++ b/src/credentials/backgroundOps.ts
@@ -1,0 +1,270 @@
+// Two background-ops orchestrators that solve operational gaps every auth deployment
+// hits at scale but no one writes from scratch correctly:
+//
+//   1) `runEmailBreachScan` re-scans existing user emails against HaveIBeenPwned's
+//      breached-account database. Passwords are checked at login (`isPasswordCompromised`);
+//      this is the email counterpart — run it on a cron and you'll catch breaches that
+//      happen after a user signed up. Requires an HIBP API key (the email endpoint is
+//      paid, unlike the k-anonymity password range API).
+//
+//   2) `pruneInactiveUsers` walks a user population, finds anyone whose last login is
+//      older than the threshold, and lets you delete or disable them. Pure orchestrator —
+//      the consumer supplies `iterateUsers` (so we don't need to know your user table
+//      shape) and `onDelete` (so you decide soft-delete vs hard-delete vs notify-only).
+//
+// Both functions are store-agnostic. We don't add list/iterate methods to `CredentialStore`
+// because the consumer's user table is the source of truth for "who exists" and "when did
+// they last log in" — credentials are auth material, not the user registry.
+
+const HIBP_BREACHED_ACCOUNT_URL =
+	'https://haveibeenpwned.com/api/v3/breachedaccount/';
+const HIBP_USER_AGENT = '@absolutejs/auth breach scanner';
+const DEFAULT_PAUSE_MS = 1700;
+const HIBP_NOT_FOUND = 404;
+const HIBP_RATE_LIMITED = 429;
+const MS_PER_DAY = 86_400_000;
+const MS_PER_SECOND = 1000;
+
+export type BreachRecord = {
+	addedDate: string;
+	dataClasses?: string[];
+	name: string;
+};
+
+export type EmailBreachEvent = {
+	breaches: BreachRecord[];
+	email: string;
+};
+
+export type EmailBreachScanInput = {
+	hibpApiKey: string;
+	// Cursor-based pager. Return `nextCursor: undefined` to stop. The pager owns its own
+	// batching — typical implementations select N rows, return them as `emails`, and pass
+	// the last row's id back as `nextCursor`.
+	iterateEmails: (
+		cursor: string | undefined
+	) => Promise<{ emails: string[]; nextCursor: string | undefined }>;
+	// Called once per email with at least one breach hit. Returning a rejected promise will
+	// abort the scan — wrap your own writes in try/catch if you want to keep going.
+	onBreachFound: (event: EmailBreachEvent) => Promise<void> | void;
+	// HIBP's documented rate limit is one request per ~1.5s on the cheapest tier. We default
+	// to 1700ms; override if you have a higher tier or are sharing the budget.
+	pauseMs?: number;
+	// Set to true to ask HIBP for `truncateResponse=false` (returns the full breach object
+	// with `dataClasses`). Costs more bandwidth; default false matches HIBP's default.
+	truncateResponse?: boolean;
+};
+
+export type EmailBreachScanResult = {
+	breached: number;
+	scanned: number;
+};
+
+const sleep = (delayMs: number) =>
+	// eslint-disable-next-line promise/avoid-new -- minimal sleep helper; setTimeout has no Promise-returning alternative
+	new Promise<void>((resolve) => {
+		setTimeout(resolve, delayMs);
+	});
+
+const isBreachRecord = (entry: unknown): entry is BreachRecord => {
+	if (typeof entry !== 'object' || entry === null) return false;
+	if (!('name' in entry)) return false;
+	const candidate: { name?: unknown } = entry;
+
+	return typeof candidate.name === 'string';
+};
+
+const isBreachRecordArray = (value: unknown): value is BreachRecord[] =>
+	Array.isArray(value) && value.every(isBreachRecord);
+
+const checkEmailBreaches = async (
+	email: string,
+	apiKey: string,
+	truncate: boolean
+) => {
+	const url = `${HIBP_BREACHED_ACCOUNT_URL}${encodeURIComponent(email)}?truncateResponse=${truncate ? 'true' : 'false'}`;
+	const response = await fetch(url, {
+		headers: {
+			'hibp-api-key': apiKey,
+			'user-agent': HIBP_USER_AGENT
+		}
+	});
+	if (response.status === HIBP_NOT_FOUND) return [];
+	if (response.status === HIBP_RATE_LIMITED) {
+		const retryAfter = Number(response.headers.get('retry-after') ?? '0');
+		if (retryAfter > 0) await sleep(retryAfter * MS_PER_SECOND);
+
+		return [];
+	}
+	if (!response.ok) return [];
+
+	const body: unknown = await response.json();
+	if (!isBreachRecordArray(body)) return [];
+
+	return body;
+};
+
+const scanEmail = async (
+	email: string,
+	apiKey: string,
+	truncate: boolean,
+	onBreachFound: EmailBreachScanInput['onBreachFound']
+) => {
+	const breaches = await checkEmailBreaches(email, apiKey, truncate);
+	if (breaches.length === 0) return false;
+	await onBreachFound({ breaches, email });
+
+	return true;
+};
+
+type ScanPageOptions = {
+	apiKey: string;
+	emails: string[];
+	onBreachFound: EmailBreachScanInput['onBreachFound'];
+	pauseMs: number;
+	truncate: boolean;
+};
+
+const scanPage = async (options: ScanPageOptions) => {
+	let scanned = 0;
+	let breached = 0;
+	for (const email of options.emails) {
+		scanned += 1;
+		// eslint-disable-next-line no-await-in-loop -- HIBP rate-limit gate enforces serial requests
+		const hit = await scanEmail(
+			email,
+			options.apiKey,
+			options.truncate,
+			options.onBreachFound
+		);
+		if (hit) breached += 1;
+		// eslint-disable-next-line no-await-in-loop -- sleep is the rate-limit; awaiting it is the entire point
+		await sleep(options.pauseMs);
+	}
+
+	return { breached, scanned };
+};
+
+export const runEmailBreachScan = async (input: EmailBreachScanInput) => {
+	const pauseMs = input.pauseMs ?? DEFAULT_PAUSE_MS;
+	const truncate = input.truncateResponse ?? true;
+	let scanned = 0;
+	let breached = 0;
+	let cursor: string | undefined;
+
+	do {
+		// eslint-disable-next-line no-await-in-loop -- pager is intentionally serial; consumer controls batch size
+		const page = await input.iterateEmails(cursor);
+		// eslint-disable-next-line no-await-in-loop -- one page at a time keeps memory and rate-limit predictable
+		const tally = await scanPage({
+			apiKey: input.hibpApiKey,
+			emails: page.emails,
+			onBreachFound: input.onBreachFound,
+			pauseMs,
+			truncate
+		});
+		scanned += tally.scanned;
+		breached += tally.breached;
+		cursor = page.nextCursor;
+	} while (cursor !== undefined);
+
+	const result: EmailBreachScanResult = { breached, scanned };
+
+	return result;
+};
+
+export type InactiveUserCandidate = {
+	// `null` means "never logged in" — counted as inactive iff the user is older than the
+	// threshold (we compare against `createdAt` instead, when present).
+	createdAt?: number;
+	lastLoginAt: number | null;
+	userId: string;
+};
+
+export type PruneInactiveUsersInput = {
+	dryRun?: boolean;
+	// Same shape as EmailBreachScanInput: cursor in, page + next cursor out.
+	iterateUsers: (
+		cursor: string | undefined
+	) => Promise<{
+		nextCursor: string | undefined;
+		users: InactiveUserCandidate[];
+	}>;
+	now?: () => number;
+	olderThanDays: number;
+	// Called for each user that crosses the threshold. The consumer decides what "prune"
+	// means (soft delete, hard delete, disable + notify). Skipped in dryRun mode.
+	onDelete: (userId: string) => Promise<void> | void;
+};
+
+export type PruneInactiveUsersResult = {
+	dryRun: boolean;
+	prunedUserIds: string[];
+	scanned: number;
+};
+
+const pruneCandidate = async (
+	candidate: InactiveUserCandidate,
+	cutoff: number,
+	dryRun: boolean,
+	onDelete: PruneInactiveUsersInput['onDelete']
+) => {
+	const reference = candidate.lastLoginAt ?? candidate.createdAt;
+	if (reference === undefined || reference === null) return false;
+	if (reference >= cutoff) return false;
+	if (!dryRun) await onDelete(candidate.userId);
+
+	return true;
+};
+
+type PrunePageOptions = {
+	candidates: InactiveUserCandidate[];
+	cutoff: number;
+	dryRun: boolean;
+	onDelete: PruneInactiveUsersInput['onDelete'];
+};
+
+const prunePage = async (options: PrunePageOptions) => {
+	const pruned: string[] = [];
+	for (const candidate of options.candidates) {
+		// eslint-disable-next-line no-await-in-loop -- deletes are sequential by design (predictable ordering, kinder to downstream stores)
+		const removed = await pruneCandidate(
+			candidate,
+			options.cutoff,
+			options.dryRun,
+			options.onDelete
+		);
+		if (removed) pruned.push(candidate.userId);
+	}
+
+	return pruned;
+};
+
+export const pruneInactiveUsers = async (input: PruneInactiveUsersInput) => {
+	const now = input.now?.() ?? Date.now();
+	const thresholdMs = input.olderThanDays * MS_PER_DAY;
+	const cutoff = now - thresholdMs;
+	const dryRun = input.dryRun ?? false;
+	const prunedUserIds: string[] = [];
+	let scanned = 0;
+	let cursor: string | undefined;
+
+	do {
+		// eslint-disable-next-line no-await-in-loop -- serial paging; the consumer controls batch size
+		const page = await input.iterateUsers(cursor);
+		scanned += page.users.length;
+		// eslint-disable-next-line no-await-in-loop -- one page at a time so memory & DB pressure stay bounded
+		const removed = await prunePage({
+			candidates: page.users,
+			cutoff,
+			dryRun,
+			onDelete: input.onDelete
+		});
+		prunedUserIds.push(...removed);
+		cursor = page.nextCursor;
+	} while (cursor !== undefined);
+
+	const result: PruneInactiveUsersResult = { dryRun, prunedUserIds, scanned };
+
+	return result;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,6 +469,7 @@ export * from './crypto';
 export * from './tenancy';
 export * from './credentials/config';
 export * from './credentials/passwordPolicy';
+export * from './credentials/backgroundOps';
 export * from './credentials/emailValidation';
 export {
 	importUser,

--- a/tests/backgroundOps.test.ts
+++ b/tests/backgroundOps.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+	pruneInactiveUsers,
+	runEmailBreachScan
+} from '../src/credentials/backgroundOps';
+
+// `runEmailBreachScan` + `pruneInactiveUsers` are store-agnostic orchestrators — the
+// consumer plugs in `iterateEmails` / `iterateUsers` (paged) and an event callback.
+// These tests confirm the paging contract, the HIBP response handling (200/404/!ok),
+// and the dryRun + missing-lastLogin paths for the pruner.
+
+const MS_PER_DAY = 86_400_000;
+const REF_NOW = 1_700_000_000_000;
+const FRESH_DAYS = 5;
+const STALE_DAYS = 200;
+const VERY_OLD_DAYS = 400;
+const ONE_DAY = 1;
+const THRESHOLD_30_DAYS = 30;
+const THRESHOLD_90_DAYS = 90;
+const PAST_YEAR_DAYS = 365;
+const HUNDRED_DAYS = 100;
+const TWO_DAYS = 2;
+const THREE_HUNDRED_DAYS = 300;
+const FOUR_USERS = 4;
+const THREE_USERS = 3;
+const HTTP_404 = 404;
+const HTTP_500 = 500;
+
+const stubFetch = (handler: (url: string) => Response) =>
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test stub for fetch
+	mock(async (input: RequestInfo | URL) =>
+		handler(input.toString())
+	) as unknown as typeof fetch;
+
+const installFetch = (handler: (url: string) => Response) => {
+	const original = globalThis.fetch;
+	globalThis.fetch = stubFetch(handler);
+
+	return () => {
+		globalThis.fetch = original;
+	};
+};
+
+describe('runEmailBreachScan', () => {
+	test('reports breaches for emails that HIBP confirms and skips 404s', async () => {
+		const restore = installFetch((url) => {
+			if (url.includes('breached%40example.com')) {
+				return new Response(
+					JSON.stringify([{ addedDate: '2025-01-01', name: 'Adobe' }])
+				);
+			}
+
+			return new Response(null, { status: HTTP_404 });
+		});
+		const events: string[] = [];
+		const pages = [
+			['safe@example.com', 'breached@example.com'],
+			['also-safe@example.com']
+		];
+		let pageIndex = 0;
+		const iterateEmails = async () => {
+			const current = pageIndex;
+			pageIndex += 1;
+			if (current >= pages.length) {
+				return { emails: [], nextCursor: undefined };
+			}
+
+			return {
+				emails: pages[current] ?? [],
+				nextCursor:
+					current + 1 < pages.length ? String(current + 1) : undefined
+			};
+		};
+		const result = await runEmailBreachScan({
+			hibpApiKey: 'k',
+			iterateEmails,
+			pauseMs: 0,
+			onBreachFound: (event) => {
+				events.push(event.email);
+			}
+		});
+		restore();
+
+		expect(result.scanned).toBe(THREE_USERS);
+		expect(result.breached).toBe(1);
+		expect(events).toEqual(['breached@example.com']);
+	});
+
+	test('treats non-2xx HIBP responses as no-breach (fail-open)', async () => {
+		const restore = installFetch(
+			() => new Response(null, { status: HTTP_500 })
+		);
+		// eslint-disable-next-line absolute/no-useless-function -- callback signature requires a function
+		const iterateEmails = async () => ({
+			emails: ['a@b.com'],
+			nextCursor: undefined
+		});
+		const onBreachFound = () => {
+			throw new Error('should not fire');
+		};
+		const result = await runEmailBreachScan({
+			hibpApiKey: 'k',
+			iterateEmails,
+			onBreachFound,
+			pauseMs: 0
+		});
+		restore();
+		expect(result).toEqual({ breached: 0, scanned: 1 });
+	});
+});
+
+describe('pruneInactiveUsers', () => {
+	test('selects users older than the threshold and calls onDelete', async () => {
+		const deletions: string[] = [];
+		// eslint-disable-next-line absolute/no-useless-function -- callback signature requires a function
+		const iterateUsers = async () => ({
+			nextCursor: undefined,
+			users: [
+				{ lastLoginAt: REF_NOW - STALE_DAYS * MS_PER_DAY, userId: 'stale' },
+				{ lastLoginAt: REF_NOW - FRESH_DAYS * MS_PER_DAY, userId: 'fresh' },
+				{
+					createdAt: REF_NOW - VERY_OLD_DAYS * MS_PER_DAY,
+					lastLoginAt: null,
+					userId: 'never-logged-in-old'
+				},
+				{
+					createdAt: REF_NOW - ONE_DAY * MS_PER_DAY,
+					lastLoginAt: null,
+					userId: 'never-logged-in-new'
+				}
+			]
+		});
+		const result = await pruneInactiveUsers({
+			iterateUsers,
+			olderThanDays: THRESHOLD_90_DAYS,
+			now: () => REF_NOW,
+			onDelete: (userId) => {
+				deletions.push(userId);
+			}
+		});
+
+		expect(result.scanned).toBe(FOUR_USERS);
+		expect([...result.prunedUserIds].sort()).toEqual([
+			'never-logged-in-old',
+			'stale'
+		]);
+		expect([...deletions].sort()).toEqual([
+			'never-logged-in-old',
+			'stale'
+		]);
+	});
+
+	test('dryRun reports candidates without calling onDelete', async () => {
+		const deletions: string[] = [];
+		// eslint-disable-next-line absolute/no-useless-function -- callback signature requires a function
+		const iterateUsers = async () => ({
+			nextCursor: undefined,
+			users: [
+				{
+					lastLoginAt: REF_NOW - PAST_YEAR_DAYS * MS_PER_DAY,
+					userId: 'stale'
+				}
+			]
+		});
+		const result = await pruneInactiveUsers({
+			dryRun: true,
+			iterateUsers,
+			olderThanDays: THRESHOLD_30_DAYS,
+			now: () => REF_NOW,
+			onDelete: (userId) => {
+				deletions.push(userId);
+			}
+		});
+
+		expect(result.dryRun).toBe(true);
+		expect(result.prunedUserIds).toEqual(['stale']);
+		expect(deletions).toEqual([]);
+	});
+
+	test('walks every page via the cursor contract', async () => {
+		const pageData = [
+			[{ lastLoginAt: REF_NOW - HUNDRED_DAYS * MS_PER_DAY, userId: 'a' }],
+			[{ lastLoginAt: REF_NOW - TWO_DAYS * MS_PER_DAY, userId: 'b' }],
+			[
+				{
+					lastLoginAt: REF_NOW - THREE_HUNDRED_DAYS * MS_PER_DAY,
+					userId: 'c'
+				}
+			]
+		];
+		const seenCursors: Array<string | undefined> = [];
+		const iterateUsers = async (cursor: string | undefined) => {
+			seenCursors.push(cursor);
+			const index = cursor === undefined ? 0 : Number(cursor);
+			const users = pageData[index] ?? [];
+			const nextCursor =
+				index + 1 < pageData.length ? String(index + 1) : undefined;
+
+			return { nextCursor, users };
+		};
+		const result = await pruneInactiveUsers({
+			iterateUsers,
+			olderThanDays: THRESHOLD_30_DAYS,
+			now: () => REF_NOW,
+			onDelete: () => {
+				/* noop */
+			}
+		});
+
+		expect(seenCursors).toEqual([undefined, '1', '2']);
+		expect(result.scanned).toBe(THREE_USERS);
+		expect([...result.prunedUserIds].sort()).toEqual(['a', 'c']);
+	});
+});

--- a/tests/clientComposables.test.ts
+++ b/tests/clientComposables.test.ts
@@ -15,11 +15,13 @@ import * as vueHooks from '../src/client/vue';
 const EXPECTED_API = [
 	'useMagicLink',
 	'useMfaChallenge',
+	'usePasskeyAutofill',
 	'usePasswordReset',
 	'useSessions',
 	'useSignIn',
 	'useSignOut',
-	'useSignUp'
+	'useSignUp',
+	'useUpgradeToPasskey'
 ] as const;
 
 const stubFetch = (handler: (url: string) => Response) =>


### PR DESCRIPTION
## What

**G5 — passkey UX composables** across react / vue / solid / svelte:
- `usePasskeyAutofill` drives WebAuthn conditional-UI (browser shows saved passkeys in the autofill dropdown on a focused `input` with `autocomplete="username webauthn"`).
- `useUpgradeToPasskey` queries whether the signed-in user has any passkeys, exposes a `register()` ceremony + a `shouldPrompt` flag for the "save a passkey to this device?" CTA after a password sign-in.
- New framework-agnostic `./passkeyHelpers` (`runConditionalAuthentication`, `runPasskeyRegistration`) that all four wrappers share — only the reactivity differs between them.
- `@simplewebauthn/browser` added as an **optional** peer dep + dynamic-imported on first use, so consumers that don't import a passkey composable pay nothing at load.

**G8 — background ops orchestrators** that every auth deployment hits at scale but no one writes from scratch correctly:
- `runEmailBreachScan` walks user emails through HIBP's breached-account endpoint (the email counterpart to the existing password check), rate-limit aware, fires `onBreachFound` per hit.
- `pruneInactiveUsers` walks a paged user population, identifies anyone past an `olderThanDays` threshold, and calls `onDelete` (or just reports in `dryRun` mode).
- Both store-agnostic — consumer supplies cursor-paged `iterateEmails` / `iterateUsers` callbacks, so the consumer's user table stays the source of truth.

## Tests

385 pass / 0 fail (was 376). New: `tests/backgroundOps.test.ts` (paging contract, HIBP 200/404/!ok handling, dryRun, missing-lastLogin paths). `tests/clientComposables.test.ts` parity list extended with the two new composables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey/WebAuthn authentication support with composable hooks across React, Vue, Solid, and Svelte frameworks for autofill and registration flows.
  * Introduced email breach scanning functionality to check user emails against breached-account databases.
  * Added inactive user pruning capability for account cleanup management.
* **Tests**
  * Added comprehensive test coverage for breach scanning and inactive user cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/absolutejs/absolute-auth/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->