### PR TITLE
0.38.0 — SCIM enterprise polish (G7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.37.0",
+	"version": "0.38.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -560,6 +560,7 @@ export * from './sso/types';
 export * from './sso/config';
 export * from './scim/types';
 export * from './scim/config';
+export * from './scim/extensions';
 export { scimRoutes } from './scim/routes';
 export { createInMemoryScimTokenStore } from './scim/inMemoryScimTokenStore';
 export {

--- a/src/scim/config.ts
+++ b/src/scim/config.ts
@@ -1,6 +1,7 @@
 import { generateSecureToken, hashToken } from '../crypto';
 import type { OrganizationId } from '../tenancy';
 import type { RouteString } from '../types';
+import type { ScimAttributeMap } from './extensions';
 import type {
 	ScimFilter,
 	ScimGroup,
@@ -19,6 +20,11 @@ const BEARER_PREFIX = 'Bearer ';
 // SCIM protocol + per-org bearer-token auth; the consumer owns its user table through these
 // mapping hooks, exactly like the OAuth / credentials / SSO surfaces.
 export type ScimConfig = {
+	// Optional declarative attribute mapping. When set, the package threads inbound JSON through
+	// `customAttributes.fromScim` and surfaces the result as `input.custom` on the create/replace
+	// hooks; reverse, `toScim` is merged into the SCIM resource response. The `schemas` it declares
+	// drive /Schemas + /ResourceTypes.
+	customAttributes?: ScimAttributeMap;
 	// Group hooks are optional — when omitted, the `/Groups` routes respond 501 Not Implemented.
 	getScimGroup?: (context: {
 		id: string;

--- a/src/scim/extensions.ts
+++ b/src/scim/extensions.ts
@@ -1,0 +1,89 @@
+// SCIM enterprise polish helpers — the pieces real IdP integrations need but the core
+// User/Group surface doesn't dictate. None of these touch the wire shape unless the
+// consumer opts into them via `ScimConfig.customAttributes`; pure adds.
+//
+//   1) `defineScimAttributeMap` — declarative bidirectional map between IdP attributes
+//      (e.g. Okta `manager`) and the consumer's user model (e.g. `reporting_to`). The
+//      package threads inbound JSON through `fromScim` into `ScimUserInput.custom` and
+//      serializes `ScimUser.custom` back via `toScim`. The IdP namespace is whatever URI
+//      the consumer declares (typically an enterprise extension like
+//      `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`).
+//
+//   2) `diffScimGroupMembers` — small set-diff helper so consumers can compute the add/
+//      remove deltas from a `onScimGroupReplace` call against their existing membership
+//      table without rolling their own loop.
+//
+//   3) Schema + ResourceType discovery types. The /Schemas + /ResourceTypes endpoints
+//      (in `./routes`) serialize these to the SCIM 2.0 wire format.
+
+import type { ScimGroupMember } from './types';
+
+// One attribute in a SCIM schema. Mirrors RFC 7643 §7 (Attribute Characteristics) but
+// only the fields IdPs actually look at — Okta + Azure AD probe `name`, `type`,
+// `multiValued`, `required`, `mutability`. Everything else has sensible defaults.
+export type ScimAttributeDefinition = {
+	caseExact?: boolean;
+	description?: string;
+	multiValued?: boolean;
+	mutability?: 'immutable' | 'readOnly' | 'readWrite' | 'writeOnly';
+	name: string;
+	required?: boolean;
+	returned?: 'always' | 'default' | 'never' | 'request';
+	subAttributes?: ScimAttributeDefinition[];
+	type:
+		| 'boolean'
+		| 'complex'
+		| 'dateTime'
+		| 'decimal'
+		| 'integer'
+		| 'reference'
+		| 'string';
+	uniqueness?: 'global' | 'none' | 'server';
+};
+
+// One schema (a namespace + the attributes that live under it). The consumer declares
+// these so the /Schemas endpoint can answer the IdP's probe. The package never inspects
+// the attribute list at runtime — it's discovery metadata only.
+export type ScimSchemaDefinition = {
+	attributes: ScimAttributeDefinition[];
+	description?: string;
+	id: string;
+	name: string;
+};
+
+// Bidirectional attribute mapping. `fromScim` turns inbound SCIM JSON into a custom-attribute
+// bag the consumer's hooks see on `input.custom`; `toScim` turns the same bag back into
+// JSON the package merges into the SCIM resource response. Both are optional — declare
+// only the schemas you want surfaced via /Schemas + /ResourceTypes.
+export type ScimAttributeMap = {
+	fromScim: (body: Record<string, unknown>) => Record<string, unknown>;
+	schemas?: ScimSchemaDefinition[];
+	toScim: (custom: Record<string, unknown>) => Record<string, unknown>;
+};
+
+// Identity helper so consumer-side `defineScimAttributeMap({...})` gets full inference +
+// the package can document the slot. No runtime behavior beyond pass-through.
+export const defineScimAttributeMap = (map: ScimAttributeMap) => map;
+
+export type ScimGroupMembershipDelta = {
+	added: ScimGroupMember[];
+	removed: ScimGroupMember[];
+};
+
+// Diff the previous group membership against the IdP's full-replace list and return
+// `{added, removed}`. Used inside `onScimGroupReplace`: read current members → call this
+// → apply the deltas to your membership table. Set-based so duplicates within a side
+// collapse, and the comparison key is `member.value` (the user's SCIM id).
+export const diffScimGroupMembers = (
+	current: ScimGroupMember[],
+	next: ScimGroupMember[]
+): ScimGroupMembershipDelta => {
+	const currentValues = new Set(current.map((member) => member.value));
+	const nextValues = new Set(next.map((member) => member.value));
+	const added = next.filter((member) => !currentValues.has(member.value));
+	const removed = current.filter(
+		(member) => !nextValues.has(member.value)
+	);
+
+	return { added, removed };
+};

--- a/src/scim/routes.ts
+++ b/src/scim/routes.ts
@@ -12,6 +12,10 @@ import {
 	parseFilter,
 	parseGroupInput,
 	parseUserInput,
+	resourceTypeList,
+	resourceTypeOne,
+	schemaList,
+	schemaOne,
 	scimError,
 	scimJson,
 	serviceProviderConfig,
@@ -35,6 +39,7 @@ const notImplemented = () =>
 	scimError(SCIM_NOT_IMPLEMENTED, 'Group provisioning is not configured');
 
 export const scimRoutes = ({
+	customAttributes,
 	getScimGroup,
 	getScimUser,
 	listScimGroups,
@@ -53,11 +58,22 @@ export const scimRoutes = ({
 	const groupsRoute: RouteString = `${scimRoute}/Groups`;
 	const groupRoute: RouteString = `${scimRoute}/Groups/:id`;
 	const spcRoute: RouteString = `${scimRoute}/ServiceProviderConfig`;
+	const schemasRoute: RouteString = `${scimRoute}/Schemas`;
+	const schemaRoute: RouteString = `${scimRoute}/Schemas/:id`;
+	const resourceTypesRoute: RouteString = `${scimRoute}/ResourceTypes`;
+	const resourceTypeRoute: RouteString = `${scimRoute}/ResourceTypes/:id`;
+	const extensionSchemas = customAttributes?.schemas ?? [];
 
 	const userLocation = (requestUrl: string, id: string) =>
 		`${new URL(requestUrl).origin}${scimRoute}/Users/${id}`;
 	const groupLocation = (requestUrl: string, id: string) =>
 		`${new URL(requestUrl).origin}${scimRoute}/Groups/${id}`;
+	const schemasLocation = (requestUrl: string) =>
+		`${new URL(requestUrl).origin}${scimRoute}/Schemas`;
+	const resourceTypesLocation = (requestUrl: string) =>
+		`${new URL(requestUrl).origin}${scimRoute}/ResourceTypes`;
+	const usersEndpoint = `${scimRoute}/Users`;
+	const groupsEndpoint = `${scimRoute}/Groups`;
 
 	return (
 		new Elysia()
@@ -87,7 +103,7 @@ export const scimRoutes = ({
 				);
 				if (organizationId === undefined) return unauthorized();
 
-				const input = parseUserInput(body);
+				const input = parseUserInput(body, customAttributes);
 				if (input === undefined) {
 					return scimError(
 						SCIM_BAD_REQUEST,
@@ -99,7 +115,11 @@ export const scimRoutes = ({
 				const user = await onScimUserCreate({ input, organizationId });
 
 				return scimJson(
-					toUserResource(user, userLocation(request.url, user.id)),
+					toUserResource(
+						user,
+						userLocation(request.url, user.id),
+						customAttributes
+					),
 					SCIM_CREATED
 				);
 			})
@@ -117,7 +137,11 @@ export const scimRoutes = ({
 						organizationId
 					});
 					const resources = users.map((user) =>
-						toUserResource(user, userLocation(request.url, user.id))
+						toUserResource(
+							user,
+							userLocation(request.url, user.id),
+							customAttributes
+						)
 					);
 
 					return scimJson(listResponse(resources), SCIM_OK);
@@ -139,7 +163,11 @@ export const scimRoutes = ({
 					}
 
 					return scimJson(
-						toUserResource(user, userLocation(request.url, id)),
+						toUserResource(
+							user,
+							userLocation(request.url, id),
+							customAttributes
+						),
 						SCIM_OK
 					);
 				},
@@ -154,7 +182,7 @@ export const scimRoutes = ({
 					);
 					if (organizationId === undefined) return unauthorized();
 
-					const input = parseUserInput(body);
+					const input = parseUserInput(body, customAttributes);
 					if (input === undefined) {
 						return scimError(
 							SCIM_BAD_REQUEST,
@@ -173,7 +201,11 @@ export const scimRoutes = ({
 					}
 
 					return scimJson(
-						toUserResource(user, userLocation(request.url, id)),
+						toUserResource(
+							user,
+							userLocation(request.url, id),
+							customAttributes
+						),
 						SCIM_OK
 					);
 				},
@@ -203,7 +235,11 @@ export const scimRoutes = ({
 					}
 
 					return scimJson(
-						toUserResource(user, userLocation(request.url, id)),
+						toUserResource(
+							user,
+							userLocation(request.url, id),
+							customAttributes
+						),
 						SCIM_OK
 					);
 				},
@@ -387,6 +423,85 @@ export const scimRoutes = ({
 					await onScimGroupDelete({ id, organizationId });
 
 					return new Response(null, { status: SCIM_NO_CONTENT });
+				},
+				{ params: t.Object({ id: t.String() }) }
+			)
+			// /Schemas + /ResourceTypes are required-but-not-always-shipped pieces of SCIM 2.0
+			// discovery. Okta + Azure AD probe them during connection setup; with the core schemas
+			// always emitted and the consumer's `customAttributes.schemas` appended, the IdP gets
+			// a complete answer instead of the 404/501 we used to return.
+			.get(schemasRoute, async ({ headers, request }) => {
+				const organizationId = await resolveScimOrganization(
+					scimTokenStore,
+					headers.authorization
+				);
+				if (organizationId === undefined) return unauthorized();
+
+				return scimJson(
+					schemaList(schemasLocation(request.url), extensionSchemas),
+					SCIM_OK
+				);
+			})
+			.get(
+				schemaRoute,
+				async ({ headers, params: { id }, request }) => {
+					const organizationId = await resolveScimOrganization(
+						scimTokenStore,
+						headers.authorization
+					);
+					if (organizationId === undefined) return unauthorized();
+
+					const schema = schemaOne(
+						`${schemasLocation(request.url)}/${id}`,
+						id,
+						extensionSchemas
+					);
+					if (schema === undefined) {
+						return scimError(SCIM_NOT_FOUND, 'Schema not found');
+					}
+
+					return scimJson(schema, SCIM_OK);
+				},
+				{ params: t.Object({ id: t.String() }) }
+			)
+			.get(resourceTypesRoute, async ({ headers, request }) => {
+				const organizationId = await resolveScimOrganization(
+					scimTokenStore,
+					headers.authorization
+				);
+				if (organizationId === undefined) return unauthorized();
+
+				return scimJson(
+					resourceTypeList(
+						resourceTypesLocation(request.url),
+						usersEndpoint,
+						groupsEndpoint,
+						extensionSchemas
+					),
+					SCIM_OK
+				);
+			})
+			.get(
+				resourceTypeRoute,
+				async ({ headers, params: { id }, request }) => {
+					const organizationId = await resolveScimOrganization(
+						scimTokenStore,
+						headers.authorization
+					);
+					if (organizationId === undefined) return unauthorized();
+
+					const resourceType = resourceTypeOne(
+						`${resourceTypesLocation(request.url)}/${id}`,
+						id,
+						usersEndpoint,
+						groupsEndpoint,
+						extensionSchemas
+					);
+					if (resourceType === undefined) {
+						return scimError(SCIM_NOT_FOUND, 'ResourceType not found');
+					}
+
+					return scimJson(resourceType, SCIM_OK);
 				},
 				{ params: t.Object({ id: t.String() }) }
 			)

--- a/src/scim/serialize.ts
+++ b/src/scim/serialize.ts
@@ -1,4 +1,9 @@
 import type {
+	ScimAttributeDefinition,
+	ScimAttributeMap,
+	ScimSchemaDefinition
+} from './extensions';
+import type {
 	ScimFilter,
 	ScimGroup,
 	ScimGroupInput,
@@ -12,13 +17,40 @@ const LIST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse';
 const ERROR_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:Error';
 const SPC_SCHEMA =
 	'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig';
+const SCHEMA_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema';
+const RESOURCE_TYPE_SCHEMA =
+	'urn:ietf:params:scim:schemas:core:2.0:ResourceType';
 const SCIM_CONTENT_TYPE = 'application/scim+json';
 const FILTER_MAX_RESULTS = 200;
 
 const FILTER_PATTERN = /^\s*(\w[\w.]*)\s+eq\s+"([^"]*)"\s*$/u;
 
-// Serialize the package's normalized user into the SCIM 2.0 User wire format.
-export const toUserResource = (user: ScimUser, location: string) => {
+const mergeCustomSchemas = (
+	resource: Record<string, unknown>,
+	custom: Record<string, unknown> | undefined,
+	map: ScimAttributeMap | undefined
+) => {
+	if (custom === undefined || map === undefined) return;
+	const extra = map.toScim(custom);
+	for (const [key, value] of Object.entries(extra)) {
+		resource[key] = value;
+	}
+	const extraSchemas = (map.schemas ?? []).map((schema) => schema.id);
+	if (extraSchemas.length === 0) return;
+	const { schemas } = resource;
+	if (Array.isArray(schemas)) {
+		resource.schemas = [...schemas, ...extraSchemas];
+	}
+};
+
+// Serialize the package's normalized user into the SCIM 2.0 User wire format. When
+// `customAttributes` is configured on the route, the consumer's `toScim` bag is merged
+// into the resource and the extension schema URIs are appended to `schemas`.
+export const toUserResource = (
+	user: ScimUser,
+	location: string,
+	map?: ScimAttributeMap
+) => {
 	const resource: Record<string, unknown> = {
 		active: user.active,
 		id: user.id,
@@ -37,6 +69,7 @@ export const toUserResource = (user: ScimUser, location: string) => {
 	if (user.email !== undefined) {
 		resource.emails = [{ primary: true, value: user.email }];
 	}
+	mergeCustomSchemas(resource, user.custom, map);
 
 	return resource;
 };
@@ -61,7 +94,12 @@ const primaryEmail = (emails: unknown) => {
 };
 
 // Parse an incoming SCIM User body into the normalized input the mapping hooks read.
-export const parseUserInput = (body: unknown): ScimUserInput | undefined => {
+// When `customAttributes` is configured, the consumer's `fromScim` projects the raw body
+// into a custom-attribute bag that lands on `input.custom`.
+export const parseUserInput = (
+	body: unknown,
+	map?: ScimAttributeMap
+): ScimUserInput | undefined => {
 	if (typeof body !== 'object' || body === null) return undefined;
 
 	const userName = stringField(body, 'userName');
@@ -69,9 +107,18 @@ export const parseUserInput = (body: unknown): ScimUserInput | undefined => {
 
 	const active = Reflect.get(body, 'active');
 	const name = Reflect.get(body, 'name');
+	// Body has already been narrowed to a non-null object above; building the bag entry-
+	// by-entry keeps the consumer mapper's Record<string, unknown> contract without an
+	// assertion or a structural cast.
+	const bodyRecord: Record<string, unknown> = {};
+	for (const key of Object.keys(body)) {
+		bodyRecord[key] = Reflect.get(body, key);
+	}
+	const custom = map === undefined ? undefined : map.fromScim(bodyRecord);
 
 	return {
 		active: typeof active === 'boolean' ? active : true,
+		custom,
 		displayName: stringField(body, 'displayName'),
 		email: primaryEmail(Reflect.get(body, 'emails')),
 		externalId: stringField(body, 'externalId'),
@@ -138,6 +185,7 @@ const applyOperation = (target: ScimUserInput, operation: unknown) => {
 export const applyPatch = (user: ScimUser, body: unknown) => {
 	const next: ScimUserInput = {
 		active: user.active,
+		custom: user.custom,
 		displayName: user.displayName,
 		email: user.email,
 		externalId: user.externalId,
@@ -193,6 +241,16 @@ export const scimJson = (resource: unknown, httpStatus: number) =>
 		status: httpStatus
 	});
 export const serviceProviderConfig = (location: string) => ({
+	authenticationSchemes: [
+		{
+			description:
+				'Authentication scheme using the OAuth Bearer Token Standard',
+			name: 'OAuth Bearer Token',
+			primary: true,
+			specUri: 'https://www.rfc-editor.org/info/rfc6750',
+			type: 'oauthbearertoken'
+		}
+	],
 	bulk: { maxOperations: 0, maxPayloadSize: 0, supported: false },
 	changePassword: { supported: false },
 	etag: { supported: false },
@@ -202,6 +260,168 @@ export const serviceProviderConfig = (location: string) => ({
 	schemas: [SPC_SCHEMA],
 	sort: { supported: false }
 });
+
+const CORE_USER_ATTRIBUTES: ScimAttributeDefinition[] = [
+	{ multiValued: false, name: 'userName', required: true, type: 'string' },
+	{ multiValued: false, name: 'active', required: false, type: 'boolean' },
+	{ multiValued: false, name: 'displayName', required: false, type: 'string' },
+	{ multiValued: false, name: 'externalId', required: false, type: 'string' },
+	{
+		multiValued: false,
+		name: 'name',
+		required: false,
+		subAttributes: [
+			{ multiValued: false, name: 'givenName', required: false, type: 'string' },
+			{ multiValued: false, name: 'familyName', required: false, type: 'string' }
+		],
+		type: 'complex'
+	},
+	{
+		multiValued: true,
+		name: 'emails',
+		required: false,
+		subAttributes: [
+			{ multiValued: false, name: 'value', required: false, type: 'string' },
+			{ multiValued: false, name: 'primary', required: false, type: 'boolean' }
+		],
+		type: 'complex'
+	}
+];
+
+const CORE_GROUP_ATTRIBUTES: ScimAttributeDefinition[] = [
+	{ multiValued: false, name: 'displayName', required: true, type: 'string' },
+	{ multiValued: false, name: 'externalId', required: false, type: 'string' },
+	{
+		multiValued: true,
+		name: 'members',
+		required: false,
+		subAttributes: [
+			{ multiValued: false, name: 'value', required: false, type: 'string' },
+			{ multiValued: false, name: 'display', required: false, type: 'string' }
+		],
+		type: 'complex'
+	}
+];
+
+const CORE_USER_SCHEMA: ScimSchemaDefinition = {
+	attributes: CORE_USER_ATTRIBUTES,
+	description: 'User Account',
+	id: USER_SCHEMA,
+	name: 'User'
+};
+
+const CORE_GROUP_SCHEMA: ScimSchemaDefinition = {
+	attributes: CORE_GROUP_ATTRIBUTES,
+	description: 'Group',
+	id: GROUP_SCHEMA,
+	name: 'Group'
+};
+
+const schemaResource = (
+	schema: ScimSchemaDefinition,
+	location: string
+): Record<string, unknown> => ({
+	attributes: schema.attributes,
+	description: schema.description ?? schema.name,
+	id: schema.id,
+	meta: { location, resourceType: 'Schema' },
+	name: schema.name
+});
+
+// `/Schemas` — full registry the IdP can probe to learn what attributes this server knows
+// about. Always includes the two core schemas; appends consumer-declared extensions.
+export const schemaList = (
+	location: string,
+	extras: ScimSchemaDefinition[] = []
+) => {
+	const all = [CORE_USER_SCHEMA, CORE_GROUP_SCHEMA, ...extras];
+	const resources = all.map((schema) =>
+		schemaResource(schema, `${location}/${schema.id}`)
+	);
+
+	return listResponse(resources);
+};
+
+// `/Schemas/:id` — one schema by URI.
+export const schemaOne = (
+	location: string,
+	id: string,
+	extras: ScimSchemaDefinition[] = []
+) => {
+	const all = [CORE_USER_SCHEMA, CORE_GROUP_SCHEMA, ...extras];
+	const found = all.find((schema) => schema.id === id);
+	if (found === undefined) return undefined;
+
+	return schemaResource(found, location);
+};
+
+const resourceTypeUser = (
+	location: string,
+	usersEndpoint: string,
+	extensionSchemaIds: string[]
+) => ({
+	description: 'User Account',
+	endpoint: usersEndpoint,
+	id: 'User',
+	meta: { location, resourceType: 'ResourceType' },
+	name: 'User',
+	schema: USER_SCHEMA,
+	schemaExtensions: extensionSchemaIds.map((schema) => ({
+		required: false,
+		schema
+	})),
+	schemas: [RESOURCE_TYPE_SCHEMA]
+});
+
+const resourceTypeGroup = (location: string, groupsEndpoint: string) => ({
+	description: 'Group',
+	endpoint: groupsEndpoint,
+	id: 'Group',
+	meta: { location, resourceType: 'ResourceType' },
+	name: 'Group',
+	schema: GROUP_SCHEMA,
+	schemas: [RESOURCE_TYPE_SCHEMA]
+});
+
+// `/ResourceTypes` — both User + Group, with the consumer's extension schemas attached
+// to the User type (the only one extensions land on in practice).
+export const resourceTypeList = (
+	location: string,
+	usersEndpoint: string,
+	groupsEndpoint: string,
+	extras: ScimSchemaDefinition[] = []
+) =>
+	listResponse([
+		resourceTypeUser(
+			`${location}/User`,
+			usersEndpoint,
+			extras.map((schema) => schema.id)
+		),
+		resourceTypeGroup(`${location}/Group`, groupsEndpoint)
+	]);
+
+// `/ResourceTypes/:id` — one resource type by name.
+export const resourceTypeOne = (
+	location: string,
+	id: string,
+	usersEndpoint: string,
+	groupsEndpoint: string,
+	extras: ScimSchemaDefinition[] = []
+) => {
+	if (id === 'User') {
+		return resourceTypeUser(
+			location,
+			usersEndpoint,
+			extras.map((schema) => schema.id)
+		);
+	}
+	if (id === 'Group') return resourceTypeGroup(location, groupsEndpoint);
+
+	return undefined;
+};
+
+// Re-export for the routes module that builds /Schemas + /ResourceTypes URLs.
+export { RESOURCE_TYPE_SCHEMA, SCHEMA_SCHEMA };
 
 const REMOVE_MEMBER_PATTERN = /^members\[\s*value\s+eq\s+"([^"]*)"\s*\]$/iu;
 

--- a/src/scim/types.ts
+++ b/src/scim/types.ts
@@ -19,9 +19,11 @@ export type ScimTokenStore = {
 
 // The package's normalized view of a SCIM User — the shape the consumer's mapping hooks read and
 // return. The package serializes it to/from the SCIM 2.0 wire format (schemas, name, emails,
-// meta, …) so the consumer never touches SCIM JSON.
+// meta, …) so the consumer never touches SCIM JSON. `custom` carries the bag produced by
+// `ScimConfig.customAttributes.fromScim` so the consumer's hooks see one merged shape.
 export type ScimUser = {
 	active: boolean;
+	custom?: Record<string, unknown>;
 	displayName?: string;
 	email?: string;
 	externalId?: string;
@@ -34,6 +36,7 @@ export type ScimUser = {
 // A SCIM User to create or replace — `ScimUser` without the server-assigned `id`.
 export type ScimUserInput = {
 	active: boolean;
+	custom?: Record<string, unknown>;
 	displayName?: string;
 	email?: string;
 	externalId?: string;

--- a/tests/scimExtensions.test.ts
+++ b/tests/scimExtensions.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { auth } from '../src/index';
+import {
+	createScimToken,
+	type ScimConfig
+} from '../src/scim/config';
+import {
+	defineScimAttributeMap,
+	diffScimGroupMembers
+} from '../src/scim/extensions';
+import { createInMemoryScimTokenStore } from '../src/scim/inMemoryScimTokenStore';
+import type {
+	ScimFilter,
+	ScimGroupMember,
+	ScimUser,
+	ScimUserInput
+} from '../src/scim/types';
+
+// G7 SCIM polish: attribute mapping, group membership diff, /Schemas + /ResourceTypes.
+
+type TestUser = { email: string; sub: string };
+
+const HTTP_OK = 200;
+const HTTP_CREATED = 201;
+const HTTP_NOT_FOUND = 404;
+const HTTP_UNAUTHORIZED = 401;
+const SCIM_CONTENT_TYPE = 'application/scim+json';
+const ENTERPRISE_SCHEMA =
+	'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+const RESOURCE_TYPE_SCHEMA =
+	'urn:ietf:params:scim:schemas:core:2.0:ResourceType';
+const USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group';
+const LIST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse';
+
+const users = new Map<string, ScimUser>();
+
+const getScimUser = (context: { id: string; organizationId: string }) =>
+	users.get(context.id);
+
+const listScimUsers = (context: {
+	filter?: ScimFilter;
+	organizationId: string;
+}) => {
+	void context;
+
+	return Array.from(users.values());
+};
+
+const onScimUserCreate = (context: {
+	input: ScimUserInput;
+	organizationId: string;
+}) => {
+	const user: ScimUser = { ...context.input, id: crypto.randomUUID() };
+	users.set(user.id, user);
+
+	return user;
+};
+
+const onScimUserDeactivate = (context: {
+	id: string;
+	organizationId: string;
+}) => {
+	users.delete(context.id);
+};
+
+const onScimUserReplace = (context: {
+	id: string;
+	input: ScimUserInput;
+	organizationId: string;
+}) => {
+	if (!users.has(context.id)) return undefined;
+	const user: ScimUser = { ...context.input, id: context.id };
+	users.set(context.id, user);
+
+	return user;
+};
+
+// The Okta-style admin pain: their `manager` attribute → our `reporting_to` field.
+const enterpriseMap = defineScimAttributeMap({
+	schemas: [
+		{
+			attributes: [
+				{
+					multiValued: false,
+					name: 'manager',
+					required: false,
+					type: 'string'
+				},
+				{
+					multiValued: false,
+					name: 'department',
+					required: false,
+					type: 'string'
+				}
+			],
+			description: 'Enterprise extension',
+			id: ENTERPRISE_SCHEMA,
+			name: 'EnterpriseUser'
+		}
+	],
+	fromScim: (body) => {
+		const extension = body[ENTERPRISE_SCHEMA];
+		if (typeof extension !== 'object' || extension === null) return {};
+		const manager = Reflect.get(extension, 'manager');
+		const department = Reflect.get(extension, 'department');
+		const result: Record<string, unknown> = {};
+		if (typeof manager === 'string') result.reporting_to = manager;
+		if (typeof department === 'string') result.department = department;
+
+		return result;
+	},
+	toScim: (custom) => {
+		const extension: Record<string, unknown> = {};
+		if (typeof custom.reporting_to === 'string') {
+			extension.manager = custom.reporting_to;
+		}
+		if (typeof custom.department === 'string') {
+			extension.department = custom.department;
+		}
+
+		return { [ENTERPRISE_SCHEMA]: extension };
+	}
+});
+
+const scimTokenStore = createInMemoryScimTokenStore();
+const { token } = await createScimToken(scimTokenStore, 'acme');
+const authHeader = `Bearer ${token}`;
+
+const scim: ScimConfig = {
+	customAttributes: enterpriseMap,
+	getScimUser,
+	listScimUsers,
+	onScimUserCreate,
+	onScimUserDeactivate,
+	onScimUserReplace,
+	scimTokenStore
+};
+
+const app = await auth<TestUser>({ providersConfiguration: {}, scim });
+
+describe('defineScimAttributeMap — round-trip through create + read', () => {
+	beforeEach(() => {
+		users.clear();
+	});
+
+	test('fromScim populates input.custom; toScim merges into the response', async () => {
+		const created = await app.handle(
+			new Request('http://localhost/scim/v2/Users', {
+				body: JSON.stringify({
+					active: true,
+					[ENTERPRISE_SCHEMA]: {
+						department: 'engineering',
+						manager: 'jane@acme.test'
+					},
+					schemas: [USER_SCHEMA, ENTERPRISE_SCHEMA],
+					userName: 'alice@acme.test'
+				}),
+				headers: {
+					authorization: authHeader,
+					'content-type': SCIM_CONTENT_TYPE
+				},
+				method: 'POST'
+			})
+		);
+		expect(created.status).toBe(HTTP_CREATED);
+		const createdBody = await created.json();
+		expect(createdBody[ENTERPRISE_SCHEMA]).toEqual({
+			department: 'engineering',
+			manager: 'jane@acme.test'
+		});
+		expect(createdBody.schemas).toContain(ENTERPRISE_SCHEMA);
+
+		// stored ScimUser carries the consumer's normalized custom bag
+		const [stored] = Array.from(users.values());
+		expect(stored?.custom).toEqual({
+			department: 'engineering',
+			reporting_to: 'jane@acme.test'
+		});
+
+		const fetched = await app.handle(
+			new Request(`http://localhost/scim/v2/Users/${stored?.id}`, {
+				headers: { authorization: authHeader }
+			})
+		);
+		const fetchedBody = await fetched.json();
+		expect(fetchedBody[ENTERPRISE_SCHEMA]).toEqual({
+			department: 'engineering',
+			manager: 'jane@acme.test'
+		});
+	});
+});
+
+describe('diffScimGroupMembers', () => {
+	const member = (value: string, display?: string) =>
+		(display === undefined
+			? { value }
+			: { display, value }) satisfies ScimGroupMember;
+
+	test('returns added + removed by user id', () => {
+		const delta = diffScimGroupMembers(
+			[member('u1', 'User One'), member('u2', 'User Two')],
+			[member('u2', 'User Two'), member('u3', 'User Three')]
+		);
+		expect(delta.added).toEqual([member('u3', 'User Three')]);
+		expect(delta.removed).toEqual([member('u1', 'User One')]);
+	});
+
+	test('handles empty current + empty next', () => {
+		expect(diffScimGroupMembers([], [member('u1')])).toEqual({
+			added: [member('u1')],
+			removed: []
+		});
+		expect(diffScimGroupMembers([member('u1')], [])).toEqual({
+			added: [],
+			removed: [member('u1')]
+		});
+	});
+});
+
+describe('/Schemas discovery', () => {
+	test('GET /Schemas lists core User + Group + extension schemas', async () => {
+		const response = await app.handle(
+			new Request('http://localhost/scim/v2/Schemas', {
+				headers: { authorization: authHeader }
+			})
+		);
+		expect(response.status).toBe(HTTP_OK);
+		const body = await response.json();
+		expect(body.schemas).toEqual([LIST_SCHEMA]);
+		const ids = body.Resources.map(
+			(resource: { id: string }) => resource.id
+		);
+		expect(ids).toContain(USER_SCHEMA);
+		expect(ids).toContain(GROUP_SCHEMA);
+		expect(ids).toContain(ENTERPRISE_SCHEMA);
+	});
+
+	test('GET /Schemas/:id returns one schema or 404', async () => {
+		const userSchema = await app.handle(
+			new Request(
+				`http://localhost/scim/v2/Schemas/${encodeURIComponent(USER_SCHEMA)}`,
+				{ headers: { authorization: authHeader } }
+			)
+		);
+		expect(userSchema.status).toBe(HTTP_OK);
+		const body = await userSchema.json();
+		expect(body.id).toBe(USER_SCHEMA);
+
+		const unknown = await app.handle(
+			new Request(
+				'http://localhost/scim/v2/Schemas/urn:does:not:exist',
+				{ headers: { authorization: authHeader } }
+			)
+		);
+		expect(unknown.status).toBe(HTTP_NOT_FOUND);
+	});
+
+	test('GET /Schemas without a bearer is 401', async () => {
+		const response = await app.handle(
+			new Request('http://localhost/scim/v2/Schemas')
+		);
+		expect(response.status).toBe(HTTP_UNAUTHORIZED);
+	});
+});
+
+describe('/ResourceTypes discovery', () => {
+	test('GET /ResourceTypes lists User + Group with extension hooked into User', async () => {
+		const response = await app.handle(
+			new Request('http://localhost/scim/v2/ResourceTypes', {
+				headers: { authorization: authHeader }
+			})
+		);
+		expect(response.status).toBe(HTTP_OK);
+		const body = await response.json();
+		const userType = body.Resources.find(
+			(resource: { id: string }) => resource.id === 'User'
+		);
+		expect(userType?.schemas).toEqual([RESOURCE_TYPE_SCHEMA]);
+		expect(userType?.schemaExtensions).toEqual([
+			{ required: false, schema: ENTERPRISE_SCHEMA }
+		]);
+		const groupType = body.Resources.find(
+			(resource: { id: string }) => resource.id === 'Group'
+		);
+		expect(groupType?.schema).toBe(GROUP_SCHEMA);
+	});
+
+	test('GET /ResourceTypes/:id returns one or 404', async () => {
+		const userType = await app.handle(
+			new Request('http://localhost/scim/v2/ResourceTypes/User', {
+				headers: { authorization: authHeader }
+			})
+		);
+		expect(userType.status).toBe(HTTP_OK);
+
+		const unknown = await app.handle(
+			new Request('http://localhost/scim/v2/ResourceTypes/Widget', {
+				headers: { authorization: authHeader }
+			})
+		);
+		expect(unknown.status).toBe(HTTP_NOT_FOUND);
+	});
+});


### PR DESCRIPTION
## What

**G7 — SCIM enterprise polish.** Three additive surfaces on top of the existing SCIM 2.0 Users + Groups + ServiceProviderConfig block.

### `defineScimAttributeMap`
Declarative bidirectional map between IdP attributes (Okta enterprise extension `manager` / `department`, custom schema URIs, etc.) and the consumer's user model. `fromScim` projects the raw SCIM body into a `Record<string, unknown>` bag that lands on `input.custom` for every create/replace hook; `toScim` is merged back into the SCIM resource response + appends extension schema URIs to the resource's `schemas[]`. Wired via new `ScimConfig.customAttributes` field.

### `diffScimGroupMembers(current, next)`
Returns `{added, removed}` so consumers can compute membership deltas inside `onScimGroupReplace` without rolling their own loop.

### `/Schemas` + `/ResourceTypes` discovery
Required-but-not-always-shipped pieces of SCIM 2.0 discovery (RFC 7644 §4). Okta + Azure AD probe these during connection setup; previously returned 404. Now serve the core User + Group schemas always, and append the consumer's `customAttributes.schemas` so the IdP gets a complete answer. `/ResourceTypes` advertises any extension schemas hooked into the User type via `schemaExtensions`.

`ServiceProviderConfig` also gains the required `authenticationSchemes` (OAuth Bearer Token, RFC 6750) that was missing before.

## Backward compat

`ScimUser` + `ScimUserInput` gain an OPTIONAL `custom?: Record<string, unknown>` — `undefined` when no map is configured. `applyPatch` preserves `user.custom` across PATCH ops so a non-custom-attr patch doesn't blow away enterprise extensions. Existing SCIM consumers see no behavior change.

## Tests

393 pass / 0 fail (+8 new in `tests/scimExtensions.test.ts`: attribute map round-trip via the live route, member diff, /Schemas list + by-id + 401/404 paths, /ResourceTypes list + User schemaExtensions wiring + by-id 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
