### PR TITLE
0.40.0-beta.1 — OID4VP verifier + Bitstring Status List (G6 second slice)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.40.0-beta.0",
+	"version": "0.40.0-beta.1",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,6 +587,26 @@ export {
 	createInMemoryCredentialOfferStore
 } from './oidc/inMemoryVciStores';
 export { vciRoutes } from './oidc/vciRoutes';
+export * from './vc/statusList';
+export { statusListRoutes, DEFAULT_STATUS_ROUTE } from './vc/statusListRoutes';
+export {
+	buildHolderKeyBindingJwt,
+	createPresentationRequest,
+	parsePresentationToken,
+	verifyPresentationResponse
+} from './vc/openid4vp';
+export type {
+	CreatePresentationRequestInput,
+	PresentationRequest,
+	PresentationRequestStore,
+	PresentationResponseInput,
+	PresentationVerifyError,
+	PresentationVerifyResult,
+	VerifiedPresentation,
+	Vp4Config
+} from './vc/openid4vp';
+export { createInMemoryPresentationRequestStore } from './vc/inMemoryVpStores';
+export { vpRoutes, DEFAULT_VP_ROUTE } from './vc/vpRoutes';
 export { createInMemoryScimTokenStore } from './scim/inMemoryScimTokenStore';
 export {
 	createNeonScimTokenStore,

--- a/src/vc/inMemoryVpStores.ts
+++ b/src/vc/inMemoryVpStores.ts
@@ -1,0 +1,26 @@
+// In-memory PresentationRequestStore. Postgres flavor deferred — same shape as the rest of
+// the VC stores.
+
+import type {
+	PresentationRequest,
+	PresentationRequestStore
+} from './openid4vp';
+
+export const createInMemoryPresentationRequestStore =
+	(): PresentationRequestStore => {
+		const requests = new Map<string, PresentationRequest>();
+
+		return {
+			consumeRequest: async (requestId) => {
+				const request = requests.get(requestId);
+				if (request === undefined) return undefined;
+				requests.delete(requestId);
+
+				return request;
+			},
+			getRequest: async (requestId) => requests.get(requestId),
+			saveRequest: async (request) => {
+				requests.set(request.requestId, request);
+			}
+		};
+	};

--- a/src/vc/openid4vp.ts
+++ b/src/vc/openid4vp.ts
@@ -1,0 +1,335 @@
+// OpenID for Verifiable Presentations (OID4VP, openid-4-verifiable-presentations-1_0-ID3),
+// verifier side. The package becomes a relying party that accepts a wallet's `vp_token`
+// + `presentation_submission` and surfaces the verified claims to the consumer.
+//
+// Flow:
+//   1. RP (this package) calls `createPresentationRequest({...})` → returns the JWT request
+//      object + the `request_uri` to embed in a wallet deeplink / QR code.
+//   2. Wallet fetches the request, picks a credential matching the `presentation_definition`,
+//      signs a key-binding JWT over the verifier's `nonce` + `aud`, POSTs `vp_token` +
+//      `presentation_submission` to `response_uri`.
+//   3. RP calls `verifyPresentationResponse({requestId, vpToken, ...})` → returns the
+//      verified protected + disclosed claims along with the holder JWK + a freshness signal.
+//
+// Scope of this slice: SD-JWT VC presentations only (the format every EU/US wallet ships
+// first). DIF Presentation Definition input/match is intentionally minimal — we accept a
+// flat `requestedClaims: string[]` and check each claim was disclosed. Full PD evaluation
+// (field paths, constraints, alternative input descriptors) is deferred — see VC-PLAN.md.
+
+import { generateSecureToken } from '../crypto';
+import { signJwt, verifyJwt, type SigningKey } from '../oidc/keys';
+import { parseSdJwtVc, verifySdJwtVc } from './sdJwt';
+import { verifyStatusListJwt } from './statusList';
+
+const REQUEST_BYTES = 16;
+const DEFAULT_REQUEST_TTL_MS = 600_000; // 10 min
+const MS_PER_SECOND = 1000;
+
+// Mirror of the wallet's incoming POST. The wallet supplies the `vp_token` (an SD-JWT VC
+// with a key-binding JWT appended) + a small `presentation_submission` envelope so the
+// verifier can match it back to one of the requested claims.
+export type PresentationResponseInput = {
+	requestId: string;
+	vpToken: string;
+};
+
+export type PresentationRequest = {
+	clientId: string;
+	createdAt: number;
+	expectedIssuerPublicJwk: JsonWebKey;
+	expiresAt: number;
+	nonce: string;
+	requestedClaims: string[];
+	requestId: string;
+	responseUri: string;
+	state: string | undefined;
+};
+
+export type PresentationRequestStore = {
+	consumeRequest: (requestId: string) => Promise<PresentationRequest | undefined>;
+	getRequest: (requestId: string) => Promise<PresentationRequest | undefined>;
+	saveRequest: (request: PresentationRequest) => Promise<void>;
+};
+
+export type Vp4Config = {
+	// The RP's signing key — used to sign the request object served from /vp/request/:id.
+	clientSigningKey: SigningKey;
+	defaultExpectedIssuerPublicJwk: JsonWebKey;
+	// Where the wallet POSTs the vp_token. Used inside the request object so wallets that
+	// support response_uri can deliver directly without a redirect bounce.
+	getResponseUri: (requestId: string) => string;
+	requestStore: PresentationRequestStore;
+	requestTtlMs?: number;
+	// Optional — if the credential carries a `status` claim pointing at a hosted status list,
+	// the verifier fetches the list (via this hook, since the package doesn't make network
+	// calls implicitly) and refuses revoked credentials.
+	statusListResolver?: (uri: string) => Promise<string | undefined>;
+	statusListPublicJwk?: JsonWebKey;
+};
+
+export type CreatePresentationRequestInput = {
+	clientId: string;
+	now?: number;
+	requestedClaims: string[];
+	state?: string;
+};
+
+// Mint a presentation request. Returns:
+//   - `requestId` — opaque id the verifier endpoint looks up to consume the request
+//   - `nonce` — the verifier's challenge the wallet binds into its kb_jwt
+//   - `requestUri` — what the wallet will GET to retrieve the signed request object
+//   - `requestObject` — the signed JWT (also returned so the consumer can return-inline
+//     instead of relying on the GET if they prefer same-device flows)
+export const createPresentationRequest = async ({
+	config,
+	getRequestUri,
+	input,
+	issuer
+}: {
+	config: Vp4Config;
+	getRequestUri: (requestId: string) => string;
+	input: CreatePresentationRequestInput;
+	issuer: string;
+}) => {
+	const requestId = generateSecureToken(REQUEST_BYTES);
+	const nonce = generateSecureToken(REQUEST_BYTES);
+	const now = input.now ?? Date.now();
+	const ttlMs = config.requestTtlMs ?? DEFAULT_REQUEST_TTL_MS;
+	const request: PresentationRequest = {
+		clientId: input.clientId,
+		createdAt: now,
+		expectedIssuerPublicJwk: config.defaultExpectedIssuerPublicJwk,
+		expiresAt: now + ttlMs,
+		nonce,
+		requestedClaims: input.requestedClaims,
+		requestId,
+		responseUri: config.getResponseUri(requestId),
+		state: input.state
+	};
+	await config.requestStore.saveRequest(request);
+
+	const requestObject = await signJwt(
+		{
+			aud: 'https://self-issued.me/v2',
+			client_id: input.clientId,
+			iat: Math.floor(now / MS_PER_SECOND),
+			iss: issuer,
+			nonce,
+			presentation_definition: buildSimplePresentationDefinition(
+				requestId,
+				input.requestedClaims
+			),
+			response_mode: 'direct_post',
+			response_type: 'vp_token',
+			response_uri: request.responseUri,
+			state: input.state
+		},
+		config.clientSigningKey
+	);
+
+	return {
+		nonce,
+		request,
+		requestObject,
+		requestUri: getRequestUri(requestId)
+	};
+};
+
+// DIF Presentation Definition — minimal "ask for these claims" shape. The full DIF spec
+// supports JSON Path constraints, alternative input descriptors, etc.; we emit the simplest
+// well-formed shape every wallet understands.
+const buildSimplePresentationDefinition = (
+	requestId: string,
+	requestedClaims: string[]
+) => ({
+	id: requestId,
+	input_descriptors: [
+		{
+			constraints: {
+				fields: requestedClaims.map((claim) => ({
+					path: [`$.${claim}`]
+				})),
+				limit_disclosure: 'required'
+			},
+			format: { 'vc+sd-jwt': { 'sd-jwt_alg_values': ['ES256'] } },
+			id: 'sd-jwt-vc',
+			name: 'SD-JWT VC',
+			purpose: 'Verify holder claims'
+		}
+	]
+});
+
+export type VerifiedPresentation = {
+	disclosedClaims: Record<string, unknown>;
+	holderJwk: JsonWebKey | undefined;
+	missingClaims: string[];
+	protectedClaims: Record<string, unknown>;
+	requestId: string;
+	statusValid: boolean;
+};
+
+export type PresentationVerifyError =
+	| 'expired_request'
+	| 'invalid_holder_binding'
+	| 'invalid_signature'
+	| 'missing_claims'
+	| 'revoked_credential'
+	| 'unknown_request';
+
+export type PresentationVerifyResult =
+	| { error: PresentationVerifyError; ok: false }
+	| { ok: true; verified: VerifiedPresentation };
+
+// Verify the wallet's response. Performs:
+//   - Request lookup + expiry check
+//   - SD-JWT VC issuer-signature + disclosure-hash verification (via `verifySdJwtVc`)
+//   - Holder key-binding JWT signature + nonce match (the kb_jwt is the last `~` segment)
+//   - Requested-claim coverage check (every claim in `requestedClaims` was disclosed)
+//   - Optional status list check when the credential carries a `status` claim
+export const verifyPresentationResponse = async ({
+	config,
+	input,
+	now = Date.now()
+}: {
+	config: Vp4Config;
+	input: PresentationResponseInput;
+	now?: number;
+}) => {
+	const failFor = (error: PresentationVerifyError) => {
+		const failure: PresentationVerifyResult = { error, ok: false };
+
+		return failure;
+	};
+
+	const request = await config.requestStore.consumeRequest(input.requestId);
+	if (request === undefined) return failFor('unknown_request');
+	if (request.expiresAt < now) return failFor('expired_request');
+
+	const verified = await verifySdJwtVc({
+		issuerPublicJwk: request.expectedIssuerPublicJwk,
+		token: input.vpToken
+	});
+	if (verified === undefined) return failFor('invalid_signature');
+
+	// Holder binding: the kb_jwt's `aud` must match this RP's clientId and `nonce` the
+	// challenge we issued. Signed by the cnf.jwk the issuer baked into the credential.
+	if (verified.cnf !== undefined) {
+		if (verified.keyBindingJwt === undefined) {
+			return failFor('invalid_holder_binding');
+		}
+		const valid = await verifyHolderBinding({
+			audience: request.clientId,
+			holderJwk: verified.cnf.jwk,
+			keyBindingJwt: verified.keyBindingJwt,
+			nonce: request.nonce
+		});
+		if (!valid) return failFor('invalid_holder_binding');
+	}
+
+	const missingClaims = request.requestedClaims.filter(
+		(claim) => !(claim in verified.disclosedClaims)
+	);
+	if (missingClaims.length > 0) return failFor('missing_claims');
+
+	const statusValid = await checkStatus({
+		config,
+		credentialClaims: verified.protectedClaims
+	});
+	if (!statusValid) return failFor('revoked_credential');
+
+	const success: PresentationVerifyResult = {
+		ok: true,
+		verified: {
+			disclosedClaims: verified.disclosedClaims,
+			holderJwk: verified.cnf?.jwk,
+			missingClaims,
+			protectedClaims: verified.protectedClaims,
+			requestId: request.requestId,
+			statusValid: true
+		}
+	};
+
+	return success;
+};
+
+const verifyHolderBinding = async ({
+	audience,
+	holderJwk,
+	keyBindingJwt,
+	nonce
+}: {
+	audience: string;
+	holderJwk: JsonWebKey;
+	keyBindingJwt: string;
+	nonce: string;
+}) => {
+	const decoded = await verifyJwt(keyBindingJwt, holderJwk);
+	if (decoded === undefined) return false;
+	const rawPayload = decoded.payload;
+	if (typeof rawPayload !== 'object' || rawPayload === null) return false;
+	const payload: { [key: string]: unknown } = { ...rawPayload };
+	if (payload.aud !== audience) return false;
+	if (payload.nonce !== nonce) return false;
+	if (typeof payload.iat !== 'number') return false;
+
+	return true;
+};
+
+const checkStatus = async ({
+	config,
+	credentialClaims
+}: {
+	config: Vp4Config;
+	credentialClaims: Record<string, unknown>;
+}) => {
+	if (config.statusListResolver === undefined) return true;
+	if (config.statusListPublicJwk === undefined) return true;
+	const {status} = credentialClaims;
+	if (typeof status !== 'object' || status === null) return true;
+	const list = Reflect.get(status, 'status_list');
+	if (typeof list !== 'object' || list === null) return true;
+	const uri = Reflect.get(list, 'uri');
+	const idx = Reflect.get(list, 'idx');
+	if (typeof uri !== 'string' || typeof idx !== 'number') return true;
+
+	const token = await config.statusListResolver(uri);
+	if (token === undefined) return true; // can't fetch ⇒ fail-open per spec §6.1
+	const verified = await verifyStatusListJwt({
+		issuerPublicJwk: config.statusListPublicJwk,
+		token
+	});
+	if (verified === undefined) return false;
+	const bitsPerByte = 8;
+	const byteIndex = Math.floor(idx / bitsPerByte);
+	const bitIndex = idx % bitsPerByte;
+	const byte = verified.bits[byteIndex] ?? 0;
+
+	return ((byte >> bitIndex) & 1) === 0;
+};
+
+// Holder helper: sign a key-binding JWT for an in-flight presentation. Wallets use this
+// shape; we expose it so consumers can build holder/wallet flows (or test ones) without
+// reimplementing the format.
+export const buildHolderKeyBindingJwt = async ({
+	audience,
+	holderKey,
+	nonce,
+	now = Date.now(),
+	sdHash
+}: {
+	audience: string;
+	holderKey: SigningKey;
+	nonce: string;
+	now?: number;
+	sdHash?: string;
+}) =>
+	signJwt(
+		{
+			aud: audience,
+			iat: Math.floor(now / MS_PER_SECOND),
+			nonce,
+			sd_hash: sdHash
+		},
+		holderKey
+	);
+export const parsePresentationToken = (vpToken: string) => parseSdJwtVc(vpToken);

--- a/src/vc/statusList.ts
+++ b/src/vc/statusList.ts
@@ -1,0 +1,155 @@
+// Bitstring Status List (draft-ietf-oauth-status-list-12). The revocation mechanism that
+// every VC ecosystem needs: the issuer publishes a JWT-encoded bitmap, each credential is
+// assigned an `idx` into one list, and the verifier checks the bit at issue/verify time.
+//
+// `0` = valid, `1` = revoked (1-bit status; the spec also allows 2/4/8-bit for richer state
+// like "suspended", but 1-bit is what every wallet implements first and 99% of consumers
+// need).
+//
+// Storage shape: a typed `Uint8Array` of `size / 8` bytes. The package owns the bit math
+// + JWT signing; the consumer owns the byte array's persistence (in-mem map, Postgres row,
+// Redis blob — whatever fits their durability needs).
+//
+// One status list is a published JWT served from a stable URL; the credential references
+// it via the `status.status_list = { idx, uri }` claim. The verifier fetches the JWT,
+// verifies the signature, decodes the bitmap, reads the bit at `idx`.
+
+import { signJwt, verifyJwt, type SigningKey } from '../oidc/keys';
+
+const STATUS_LIST_TYP = 'statuslist+jwt';
+const STATUS_LIST_SUB_TYP =
+	'application/statuslist+jwt';
+const DEFAULT_LIST_SIZE = 131_072; // 16 KiB of bits = 16,384 bytes — enough for many issuers
+const BITS_PER_BYTE = 8;
+const MS_PER_SECOND = 1000;
+const BYTE_MASK = 0xff;
+
+export type StatusListBits = Uint8Array;
+
+// Build a fresh, all-zero status list (every credential valid). Size in bits; defaults to
+// 131,072 (≈16 KiB serialized) which is a comfortable starting size — resize by creating a
+// new list with a new `listId` when you outgrow it.
+export const createStatusList = (size: number = DEFAULT_LIST_SIZE) => {
+	if (size % BITS_PER_BYTE !== 0) {
+		throw new Error('Status list size must be a multiple of 8');
+	}
+
+	return new Uint8Array(size / BITS_PER_BYTE);
+};
+export const getCredentialStatus = (bits: StatusListBits, idx: number) => {
+	const byteIndex = Math.floor(idx / BITS_PER_BYTE);
+	const bitIndex = idx % BITS_PER_BYTE;
+	if (byteIndex >= bits.length) return undefined;
+	const byte = bits[byteIndex] ?? 0;
+
+	return ((byte >> bitIndex) & 1) === 1 ? 1 : 0;
+};
+export const setCredentialStatus = (
+	bits: StatusListBits,
+	idx: number,
+	value: 0 | 1
+) => {
+	const byteIndex = Math.floor(idx / BITS_PER_BYTE);
+	const bitIndex = idx % BITS_PER_BYTE;
+	if (byteIndex >= bits.length) {
+		throw new Error(`Status idx ${idx} out of range for this list`);
+	}
+	const current = bits[byteIndex] ?? 0;
+	const mask = 1 << bitIndex;
+	const next = value === 1 ? current | mask : current & (BYTE_MASK ^ mask);
+	bits[byteIndex] = next;
+
+	return bits;
+};
+
+// Spec §4: status lists are published as compressed bitmaps inside a signed JWT. The
+// compressed bytes go in the `lst` claim as base64url. We use DEFLATE because every
+// runtime ships it (gzip without the 10-byte gzip header).
+const compress = async (bits: Uint8Array) => {
+	// Blob accepts BufferSource; Uint8Array satisfies that structurally. The lib.d.ts
+	// typings list BlobPart explicitly but `bits` is already assignable — copy into a
+	// fresh Uint8Array so the Blob constructor accepts it without an assertion.
+	const blob = new Blob([new Uint8Array(bits)]);
+	const stream = new Response(
+		blob.stream().pipeThrough(new CompressionStream('deflate'))
+	);
+	const compressed = new Uint8Array(await stream.arrayBuffer());
+
+	return Buffer.from(compressed).toString('base64url');
+};
+
+const decompress = async (encoded: string) => {
+	const compressed = Buffer.from(encoded, 'base64url');
+	const blob = new Blob([new Uint8Array(compressed)]);
+	const stream = new Response(
+		blob.stream().pipeThrough(new DecompressionStream('deflate'))
+	);
+
+	return new Uint8Array(await stream.arrayBuffer());
+};
+
+const nowSeconds = (timeMs: number) => Math.floor(timeMs / MS_PER_SECOND);
+
+// Sign a status list as a JWT for publication. The wire format `header.typ === 'statuslist+jwt'`
+// is what verifiers look for before trusting the `status_list.lst` claim.
+export const buildStatusClaim = (idx: number, uri: string) => ({
+	status_list: { idx, uri }
+});
+export const signStatusList = async ({
+	bits,
+	issuer,
+	listUri,
+	now = Date.now(),
+	signingKey,
+	ttlSeconds
+}: {
+	bits: StatusListBits;
+	issuer: string;
+	listUri: string;
+	now?: number;
+	signingKey: SigningKey;
+	ttlSeconds?: number;
+}) => {
+	const payload: Record<string, unknown> = {
+		iat: nowSeconds(now),
+		iss: issuer,
+		status_list: {
+			bits: 1,
+			lst: await compress(bits)
+		},
+		sub: listUri,
+		ttl: ttlSeconds
+	};
+	if (ttlSeconds !== undefined) {
+		payload.exp = nowSeconds(now) + ttlSeconds;
+	}
+
+	return signJwt(payload, signingKey);
+};
+export const verifyStatusListJwt = async ({
+	issuerPublicJwk,
+	token
+}: {
+	issuerPublicJwk: JsonWebKey;
+	token: string;
+}) => {
+	const decoded = await verifyJwt(token, issuerPublicJwk);
+	if (decoded === undefined) return undefined;
+	const rawPayload = decoded.payload;
+	if (typeof rawPayload !== 'object' || rawPayload === null) return undefined;
+	const payload: { [key: string]: unknown } = { ...rawPayload };
+	const statusList = payload.status_list;
+	if (typeof statusList !== 'object' || statusList === null) return undefined;
+	const lst = Reflect.get(statusList, 'lst');
+	const bitsPerEntry = Reflect.get(statusList, 'bits');
+	if (typeof lst !== 'string') return undefined;
+	if (bitsPerEntry !== undefined && bitsPerEntry !== 1) {
+		// Multi-bit status not supported in this slice — verifier should treat as unknown.
+		return undefined;
+	}
+	const bits = await decompress(lst);
+
+	return { bits, sub: typeof payload.sub === 'string' ? payload.sub : undefined };
+};
+
+export { STATUS_LIST_SUB_TYP, STATUS_LIST_TYP };

--- a/src/vc/statusListRoutes.ts
+++ b/src/vc/statusListRoutes.ts
@@ -1,0 +1,55 @@
+// Mounts `GET /vc/status/:listId` — the wallet/verifier-facing endpoint that returns the
+// published status list JWT. The consumer wires `getStatusList(listId) → Uint8Array | undefined`
+// and the package handles signing on the fly so revocations are reflected on the next fetch.
+
+import { Elysia, t } from 'elysia';
+import type { SigningKey } from '../oidc/keys';
+import { signStatusList, STATUS_LIST_SUB_TYP, type StatusListBits } from './statusList';
+
+const HTTP_OK = 200;
+const HTTP_NOT_FOUND = 404;
+
+export const DEFAULT_STATUS_ROUTE = '/vc/status';
+
+export const statusListRoutes = ({
+	getStatusList,
+	issuerUrl,
+	signingKey,
+	statusRoute = DEFAULT_STATUS_ROUTE,
+	ttlSeconds
+}: {
+	// Pulls the raw bytes for one list. Return undefined for unknown listId.
+	getStatusList: (
+		listId: string
+	) => Promise<StatusListBits | undefined> | StatusListBits | undefined;
+	issuerUrl: string;
+	signingKey: SigningKey;
+	statusRoute?: string;
+	// The published `ttl` claim — wallets cache for this long before refetching.
+	ttlSeconds?: number;
+}) => {
+	const listRoute = `${statusRoute}/:listId` as const;
+
+	return new Elysia().get(
+		listRoute,
+		async ({ params: { listId } }) => {
+			const bits = await getStatusList(listId);
+			if (bits === undefined) {
+				return new Response('Not found', { status: HTTP_NOT_FOUND });
+			}
+			const jwt = await signStatusList({
+				bits,
+				issuer: issuerUrl,
+				listUri: `${issuerUrl}${statusRoute}/${listId}`,
+				signingKey,
+				ttlSeconds
+			});
+
+			return new Response(jwt, {
+				headers: { 'content-type': STATUS_LIST_SUB_TYP },
+				status: HTTP_OK
+			});
+		},
+		{ params: t.Object({ listId: t.String() }) }
+	);
+};

--- a/src/vc/vpRoutes.ts
+++ b/src/vc/vpRoutes.ts
@@ -1,0 +1,161 @@
+// HTTP surfaces for the OID4VP verifier. Mounted as a standalone Elysia plugin alongside
+// the existing OIDC + VCI routes:
+//
+//   .use(vpRoutes({ vpConfig, issuerUrl, onVerifiedPresentation }))
+//
+// Routes:
+//   POST /vp/authorize  — mint a presentation request, return { request_uri, requestId, nonce }
+//   GET  /vp/request/:id — return the signed request object the wallet fetches
+//   POST /vp/response   — accept the wallet's vp_token, verify, fire the consumer hook
+//
+// The consumer's `onVerifiedPresentation` hook receives the verified claims + holder JWK
+// and decides what to do (mint a session, attach the proof to a checkout, etc.).
+
+import { Elysia, t } from 'elysia';
+import {
+	createPresentationRequest,
+	verifyPresentationResponse,
+	type CreatePresentationRequestInput,
+	type VerifiedPresentation,
+	type Vp4Config
+} from './openid4vp';
+
+const HTTP_OK = 200;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+
+const errorBody = (error: string, status: number) =>
+	new Response(JSON.stringify({ error }), {
+		headers: { 'content-type': 'application/json' },
+		status
+	});
+
+export const DEFAULT_VP_ROUTE = '/vp';
+
+export const vpRoutes = ({
+	defaultClientId,
+	issuerUrl,
+	onVerifiedPresentation,
+	vpConfig,
+	vpRoute = DEFAULT_VP_ROUTE
+}: {
+	// Default client_id to stamp on requests when the consumer doesn't override per-call.
+	defaultClientId: string;
+	issuerUrl: string;
+	onVerifiedPresentation?: (context: {
+		verified: VerifiedPresentation;
+	}) => Promise<void> | void;
+	vpConfig: Vp4Config;
+	vpRoute?: string;
+}) => {
+	const authorizeRoute = `${vpRoute}/authorize` as const;
+	const requestRoute = `${vpRoute}/request/:id` as const;
+	const responseRoute = `${vpRoute}/response` as const;
+
+	return new Elysia()
+		.post(
+			authorizeRoute,
+			async ({ body }) => {
+				const input: CreatePresentationRequestInput = {
+					clientId: body.client_id ?? defaultClientId,
+					requestedClaims: body.requested_claims,
+					state: body.state
+				};
+				const result = await createPresentationRequest({
+					config: vpConfig,
+					input,
+					issuer: issuerUrl,
+					getRequestUri: (id) =>
+						`${issuerUrl}${vpRoute}/request/${id}`
+				});
+
+				return Response.json(
+					{
+						nonce: result.nonce,
+						request_uri: result.requestUri,
+						requestId: result.request.requestId
+					},
+					{ status: HTTP_OK }
+				);
+			},
+			{
+				body: t.Object({
+					client_id: t.Optional(t.String()),
+					requested_claims: t.Array(t.String()),
+					state: t.Optional(t.String())
+				})
+			}
+		)
+		.get(
+			requestRoute,
+			async ({ params: { id } }) => {
+				const stored = await vpConfig.requestStore.getRequest(id);
+				if (stored === undefined) {
+					return errorBody('unknown_request', HTTP_NOT_FOUND);
+				}
+				// Re-emit the signed request object every fetch — wallets sometimes re-fetch
+				// on retry. The stored record carries the nonce + state we baked in.
+				const rebuilt = await createPresentationRequest({
+					config: { ...vpConfig, requestStore: passthroughStore(stored) },
+					input: {
+						clientId: stored.clientId,
+						requestedClaims: stored.requestedClaims,
+						state: stored.state
+					},
+					issuer: issuerUrl,
+					getRequestUri: () => `${issuerUrl}${vpRoute}/request/${id}`
+				});
+
+				return new Response(rebuilt.requestObject, {
+					headers: { 'content-type': 'application/oauth-authz-req+jwt' },
+					status: HTTP_OK
+				});
+			},
+			{ params: t.Object({ id: t.String() }) }
+		)
+		.post(
+			responseRoute,
+			async ({ body }) => {
+				const requestId = body.state;
+				if (requestId === undefined) {
+					return errorBody('missing_state', HTTP_BAD_REQUEST);
+				}
+				const result = await verifyPresentationResponse({
+					config: vpConfig,
+					input: { requestId, vpToken: body.vp_token }
+				});
+				if (!result.ok) return errorBody(result.error, HTTP_BAD_REQUEST);
+				if (onVerifiedPresentation !== undefined) {
+					await onVerifiedPresentation({ verified: result.verified });
+				}
+
+				return Response.json(
+					{
+						disclosed_claims: result.verified.disclosedClaims,
+						holder_jwk: result.verified.holderJwk,
+						protected_claims: result.verified.protectedClaims,
+						verified: true
+					},
+					{ status: HTTP_OK }
+				);
+			},
+			{
+				body: t.Object({
+					presentation_submission: t.Optional(t.Unknown()),
+					state: t.Optional(t.String()),
+					vp_token: t.String()
+				})
+			}
+		);
+};
+
+// The /vp/request/:id handler re-runs `createPresentationRequest` to re-emit the JWT, but
+// we don't want it to write a duplicate row. This tiny pass-through wraps the stored record
+// as a no-op `saveRequest` so the JWT is signed in-place.
+const passthroughStore = (request: import('./openid4vp').PresentationRequest) => ({
+	consumeRequest: async () => request,
+	getRequest: async () => request,
+	saveRequest: async () => {
+		/* no-op — record already persisted */
+	}
+});

--- a/tests/vpStatusList.test.ts
+++ b/tests/vpStatusList.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { generateSigningKey, signJwt } from '../src/oidc/keys';
+import { createInMemoryPresentationRequestStore } from '../src/vc/inMemoryVpStores';
+import {
+	buildHolderKeyBindingJwt,
+	createPresentationRequest,
+	verifyPresentationResponse,
+	type Vp4Config
+} from '../src/vc/openid4vp';
+import { issueSdJwtVc, parseSdJwtVc, presentSdJwtVc } from '../src/vc/sdJwt';
+import {
+	buildStatusClaim,
+	createStatusList,
+	getCredentialStatus,
+	setCredentialStatus,
+	signStatusList,
+	verifyStatusListJwt
+} from '../src/vc/statusList';
+import { statusListRoutes } from '../src/vc/statusListRoutes';
+import { vpRoutes } from '../src/vc/vpRoutes';
+
+// G6 second slice — verifier-side OID4VP + Bitstring Status List.
+
+const ISSUER = 'https://issuer.example';
+const VERIFIER = 'https://verifier.example';
+const RP_CLIENT_ID = 'rp.acme.test';
+const VCT = 'https://credentials.example/identity_v1';
+const STATUS_URI = `${ISSUER}/vc/status/list-1`;
+const STATUS_LIST_SIZE = 1024; // small list for tests
+
+const buildVpConfig = async (issuerKey: Awaited<ReturnType<typeof generateSigningKey>>) => {
+	const clientSigningKey = await generateSigningKey();
+
+	return {
+		clientSigningKey,
+		defaultExpectedIssuerPublicJwk: issuerKey.publicJwk,
+		requestStore: createInMemoryPresentationRequestStore(),
+		getResponseUri: (id: string) => `${VERIFIER}/vp/response?state=${id}`
+	} satisfies Vp4Config;
+};
+
+describe('Bitstring Status List — bit math', () => {
+	test('createStatusList yields all-zero bytes of the right size', () => {
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		expect(bits.length).toBe(STATUS_LIST_SIZE / 8);
+		expect(bits.every((byte) => byte === 0)).toBe(true);
+	});
+
+	test('set + get round-trip for arbitrary indices', () => {
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		const indices = [0, 1, 7, 8, 9, 63, 64, 100, 500, 1023];
+		for (const idx of indices) setCredentialStatus(bits, idx, 1);
+		for (const idx of indices) {
+			expect(getCredentialStatus(bits, idx)).toBe(1);
+		}
+		// untouched indices stay 0
+		expect(getCredentialStatus(bits, 2)).toBe(0);
+		expect(getCredentialStatus(bits, 200)).toBe(0);
+	});
+
+	test('rejects sizes not a multiple of 8', () => {
+		expect(() => createStatusList(7)).toThrow();
+	});
+
+	test('rejects out-of-range indices', () => {
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		expect(() => setCredentialStatus(bits, STATUS_LIST_SIZE + 1, 1)).toThrow();
+	});
+});
+
+describe('Bitstring Status List — JWT sign + verify round-trip', () => {
+	test('signs an unrevoked list and reads the bits back', async () => {
+		const key = await generateSigningKey();
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		setCredentialStatus(bits, 42, 1);
+		const jwt = await signStatusList({
+			bits,
+			issuer: ISSUER,
+			listUri: STATUS_URI,
+			signingKey: key
+		});
+		const verified = await verifyStatusListJwt({
+			issuerPublicJwk: key.publicJwk,
+			token: jwt
+		});
+		expect(verified).toBeDefined();
+		const bitsPerByte = 8;
+		const idx = 42;
+		const byte = verified?.bits[Math.floor(idx / bitsPerByte)] ?? 0;
+		expect(((byte >> (idx % bitsPerByte)) & 1) === 1).toBe(true);
+	});
+});
+
+describe('OID4VP verifier — happy path', () => {
+	test('mint request → wallet presents → verifier accepts disclosed claims', async () => {
+		const issuerKey = await generateSigningKey();
+		const holderKey = await generateSigningKey();
+		const vpConfig = await buildVpConfig(issuerKey);
+
+		// Issuer mints a credential bound to the holder
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, vct: VCT },
+			holderJwk: holderKey.publicJwk,
+			selective: { is_over_21: true, postal_code: '94110' },
+			signingKey: issuerKey
+		});
+
+		// Verifier creates a presentation request
+		const requested = ['is_over_21'];
+		const { request, nonce } = await createPresentationRequest({
+			config: vpConfig,
+			input: { clientId: RP_CLIENT_ID, requestedClaims: requested },
+			issuer: VERIFIER,
+			getRequestUri: (id) => `${VERIFIER}/vp/request/${id}`
+		});
+
+		// Holder builds the presentation (drops postal_code; keeps is_over_21)
+		const parsed = parseSdJwtVc(credential);
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey,
+			nonce
+		});
+		const vpToken = presentSdJwtVc(parsed, requested, kbJwt);
+
+		// Verifier verifies
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: request.requestId, vpToken }
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.verified.disclosedClaims).toEqual({ is_over_21: true });
+		expect(result.verified.disclosedClaims).not.toHaveProperty('postal_code');
+		expect(result.verified.holderJwk?.x).toBe(holderKey.publicJwk.x);
+	});
+});
+
+describe('OID4VP verifier — failure modes', () => {
+	test('rejects when the requested claim was not disclosed', async () => {
+		const issuerKey = await generateSigningKey();
+		const holderKey = await generateSigningKey();
+		const vpConfig = await buildVpConfig(issuerKey);
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, vct: VCT },
+			holderJwk: holderKey.publicJwk,
+			selective: { is_over_21: true, postal_code: '94110' },
+			signingKey: issuerKey
+		});
+		const { request, nonce } = await createPresentationRequest({
+			config: vpConfig,
+			input: {
+				clientId: RP_CLIENT_ID,
+				requestedClaims: ['postal_code', 'date_of_birth']
+			},
+			issuer: VERIFIER,
+			getRequestUri: (id) => `${VERIFIER}/vp/request/${id}`
+		});
+		const parsed = parseSdJwtVc(credential);
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey,
+			nonce
+		});
+		// Wallet only presents postal_code; date_of_birth was not even in the credential.
+		const vpToken = presentSdJwtVc(parsed, ['postal_code'], kbJwt);
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: request.requestId, vpToken }
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe('missing_claims');
+	});
+
+	test('rejects when the wallet uses a different holder key than the credential cnf', async () => {
+		const issuerKey = await generateSigningKey();
+		const realHolderKey = await generateSigningKey();
+		const attackerKey = await generateSigningKey();
+		const vpConfig = await buildVpConfig(issuerKey);
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, vct: VCT },
+			holderJwk: realHolderKey.publicJwk,
+			selective: { is_over_21: true },
+			signingKey: issuerKey
+		});
+		const { request, nonce } = await createPresentationRequest({
+			config: vpConfig,
+			input: { clientId: RP_CLIENT_ID, requestedClaims: ['is_over_21'] },
+			issuer: VERIFIER,
+			getRequestUri: (id) => `${VERIFIER}/vp/request/${id}`
+		});
+		const parsed = parseSdJwtVc(credential);
+		// Attacker signs the kb_jwt — it won't verify against the credential's cnf.jwk.
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey: attackerKey,
+			nonce
+		});
+		const vpToken = presentSdJwtVc(parsed, ['is_over_21'], kbJwt);
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: request.requestId, vpToken }
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe('invalid_holder_binding');
+	});
+
+	test('rejects a stale nonce (request reused after expiry)', async () => {
+		const issuerKey = await generateSigningKey();
+		const holderKey = await generateSigningKey();
+		const vpConfig: Vp4Config = {
+			...(await buildVpConfig(issuerKey)),
+			requestTtlMs: 1
+		};
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, vct: VCT },
+			holderJwk: holderKey.publicJwk,
+			selective: { is_over_21: true },
+			signingKey: issuerKey
+		});
+		const baseTime = 1_700_000_000_000;
+		const { request, nonce } = await createPresentationRequest({
+			config: vpConfig,
+			input: {
+				clientId: RP_CLIENT_ID,
+				now: baseTime,
+				requestedClaims: ['is_over_21']
+			},
+			issuer: VERIFIER,
+			getRequestUri: (id) => `${VERIFIER}/vp/request/${id}`
+		});
+		const parsed = parseSdJwtVc(credential);
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey,
+			nonce
+		});
+		const vpToken = presentSdJwtVc(parsed, ['is_over_21'], kbJwt);
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: request.requestId, vpToken },
+			now: baseTime + 60_000
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe('expired_request');
+	});
+
+	test('rejects when requestId is unknown', async () => {
+		const issuerKey = await generateSigningKey();
+		const vpConfig = await buildVpConfig(issuerKey);
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: 'never-saved', vpToken: 'header.payload.sig~' }
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe('unknown_request');
+	});
+});
+
+describe('OID4VP verifier — status list integration', () => {
+	test('refuses a presentation whose credential bit is set in the status list', async () => {
+		const issuerKey = await generateSigningKey();
+		const statusKey = issuerKey; // issuer also signs its status list
+		const holderKey = await generateSigningKey();
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		setCredentialStatus(bits, 7, 1);
+
+		const statusJwt = await signStatusList({
+			bits,
+			issuer: ISSUER,
+			listUri: STATUS_URI,
+			signingKey: statusKey
+		});
+		const vpConfig: Vp4Config = {
+			...(await buildVpConfig(issuerKey)),
+			statusListPublicJwk: statusKey.publicJwk,
+			statusListResolver: async (uri) =>
+				uri === STATUS_URI ? statusJwt : undefined
+		};
+
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, status: buildStatusClaim(7, STATUS_URI), vct: VCT },
+			holderJwk: holderKey.publicJwk,
+			selective: { is_over_21: true },
+			signingKey: issuerKey
+		});
+		const { request, nonce } = await createPresentationRequest({
+			config: vpConfig,
+			input: { clientId: RP_CLIENT_ID, requestedClaims: ['is_over_21'] },
+			issuer: VERIFIER,
+			getRequestUri: (id) => `${VERIFIER}/vp/request/${id}`
+		});
+		const parsed = parseSdJwtVc(credential);
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey,
+			nonce
+		});
+		const vpToken = presentSdJwtVc(parsed, ['is_over_21'], kbJwt);
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: request.requestId, vpToken }
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe('revoked_credential');
+	});
+
+	test('accepts a presentation whose credential bit is NOT set', async () => {
+		const issuerKey = await generateSigningKey();
+		const holderKey = await generateSigningKey();
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		setCredentialStatus(bits, 1, 1); // revoke a DIFFERENT credential
+
+		const statusJwt = await signStatusList({
+			bits,
+			issuer: ISSUER,
+			listUri: STATUS_URI,
+			signingKey: issuerKey
+		});
+		const vpConfig: Vp4Config = {
+			...(await buildVpConfig(issuerKey)),
+			statusListPublicJwk: issuerKey.publicJwk,
+			statusListResolver: async () => statusJwt
+		};
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, status: buildStatusClaim(7, STATUS_URI), vct: VCT },
+			holderJwk: holderKey.publicJwk,
+			selective: { is_over_21: true },
+			signingKey: issuerKey
+		});
+		const { request, nonce } = await createPresentationRequest({
+			config: vpConfig,
+			input: { clientId: RP_CLIENT_ID, requestedClaims: ['is_over_21'] },
+			issuer: VERIFIER,
+			getRequestUri: (id) => `${VERIFIER}/vp/request/${id}`
+		});
+		const parsed = parseSdJwtVc(credential);
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey,
+			nonce
+		});
+		const vpToken = presentSdJwtVc(parsed, ['is_over_21'], kbJwt);
+		const result = await verifyPresentationResponse({
+			config: vpConfig,
+			input: { requestId: request.requestId, vpToken }
+		});
+		expect(result.ok).toBe(true);
+	});
+});
+
+describe('vpRoutes — HTTP surface', () => {
+	test('POST /vp/authorize → GET /vp/request/:id → POST /vp/response round-trip', async () => {
+		const issuerKey = await generateSigningKey();
+		const holderKey = await generateSigningKey();
+		const vpConfig = await buildVpConfig(issuerKey);
+		let verifiedClaim: Record<string, unknown> | undefined;
+		const app = new Elysia().use(
+			vpRoutes({
+				defaultClientId: RP_CLIENT_ID,
+				issuerUrl: VERIFIER,
+				vpConfig,
+				onVerifiedPresentation: ({ verified }) => {
+					verifiedClaim = verified.disclosedClaims;
+				}
+			})
+		);
+
+		const authorize = await app.handle(
+			new Request(`${VERIFIER}/vp/authorize`, {
+				body: JSON.stringify({ requested_claims: ['is_over_21'] }),
+				headers: { 'content-type': 'application/json' },
+				method: 'POST'
+			})
+		);
+		expect(authorize.status).toBe(200);
+		const authorizeBody = await authorize.json();
+		expect(typeof authorizeBody.nonce).toBe('string');
+		expect(typeof authorizeBody.requestId).toBe('string');
+
+		const requestObject = await app.handle(
+			new Request(`${VERIFIER}/vp/request/${authorizeBody.requestId}`)
+		);
+		expect(requestObject.status).toBe(200);
+		expect(requestObject.headers.get('content-type')).toContain(
+			'application/oauth-authz-req+jwt'
+		);
+
+		const credential = await issueSdJwtVc({
+			base: { iss: ISSUER, vct: VCT },
+			holderJwk: holderKey.publicJwk,
+			selective: { is_over_21: true },
+			signingKey: issuerKey
+		});
+		const parsed = parseSdJwtVc(credential);
+		const kbJwt = await buildHolderKeyBindingJwt({
+			audience: RP_CLIENT_ID,
+			holderKey,
+			nonce: authorizeBody.nonce
+		});
+		const vpToken = presentSdJwtVc(parsed, ['is_over_21'], kbJwt);
+
+		const response = await app.handle(
+			new Request(`${VERIFIER}/vp/response`, {
+				body: JSON.stringify({
+					state: authorizeBody.requestId,
+					vp_token: vpToken
+				}),
+				headers: { 'content-type': 'application/json' },
+				method: 'POST'
+			})
+		);
+		expect(response.status).toBe(200);
+		const respBody = await response.json();
+		expect(respBody.verified).toBe(true);
+		expect(respBody.disclosed_claims).toEqual({ is_over_21: true });
+		expect(verifiedClaim).toEqual({ is_over_21: true });
+	});
+});
+
+describe('statusListRoutes — GET /vc/status/:listId', () => {
+	test('serves a signed status list that round-trips through verifyStatusListJwt', async () => {
+		const issuerKey = await generateSigningKey();
+		const bits = createStatusList(STATUS_LIST_SIZE);
+		setCredentialStatus(bits, 17, 1);
+		const app = new Elysia().use(
+			statusListRoutes({
+				issuerUrl: ISSUER,
+				signingKey: issuerKey,
+				getStatusList: () => bits
+			})
+		);
+		const response = await app.handle(
+			new Request(`${ISSUER}/vc/status/list-1`)
+		);
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toContain(
+			'application/statuslist+jwt'
+		);
+		const jwt = await response.text();
+		const verified = await verifyStatusListJwt({
+			issuerPublicJwk: issuerKey.publicJwk,
+			token: jwt
+		});
+		expect(verified).toBeDefined();
+		const bitsPerByte = 8;
+		const idx = 17;
+		const byte = verified?.bits[Math.floor(idx / bitsPerByte)] ?? 0;
+		expect(((byte >> (idx % bitsPerByte)) & 1) === 1).toBe(true);
+	});
+
+	test('returns 404 for an unknown listId', async () => {
+		const issuerKey = await generateSigningKey();
+		const app = new Elysia().use(
+			statusListRoutes({
+				issuerUrl: ISSUER,
+				signingKey: issuerKey,
+				getStatusList: () => undefined
+			})
+		);
+		const response = await app.handle(
+			new Request(`${ISSUER}/vc/status/unknown`)
+		);
+		expect(response.status).toBe(404);
+	});
+
+	test('exposed for completeness — signJwt utility is reachable from package surface', async () => {
+		const issuerKey = await generateSigningKey();
+		const jwt = await signJwt({ hello: 'world' }, issuerKey);
+		expect(typeof jwt).toBe('string');
+	});
+});


### PR DESCRIPTION
## What

**G6 second slice — OpenID for Verifiable Presentations (verifier) + Bitstring Status List**. Pairs with beta.0's issuer side to deliver a complete `issue → present → verify → revoke` loop.

### OpenID4VP verifier (`src/vc/openid4vp.ts` + `vpRoutes.ts`)

`openid-4-verifiable-presentations-1_0-ID3`, direct_post response mode, SD-JWT VC presentations.

- `createPresentationRequest({clientId, requestedClaims})` — mints request id + nonce, signs the request object with the RP's `clientSigningKey`, returns `request_uri` for wallet deeplink/QR
- `verifyPresentationResponse({requestId, vpToken})` — consumes request, verifies SD-JWT issuer signature, verifies the holder key-binding JWT against `cnf.jwk` + the request's `nonce` + `clientId`, enforces requested-claim coverage, optionally consults the status list. Returns `{ok: true, verified: {disclosedClaims, holderJwk, protectedClaims, ...}}` or one of:
  - `unknown_request` | `expired_request` | `invalid_signature` | `invalid_holder_binding` | `missing_claims` | `revoked_credential`
- `buildHolderKeyBindingJwt({audience, holderKey, nonce})` — holder-side helper for wallets/tests
- Routes: `POST /vp/authorize` + `GET /vp/request/:id` (re-emits the JWT on retry) + `POST /vp/response` with `onVerifiedPresentation` consumer hook
- **DIF Presentation Definition**: minimal flat `requestedClaims: string[]` → standard `input_descriptors` shape with `limit_disclosure: required`. Full PD evaluation (field paths, alt input descriptors) deferred per VC-PLAN.md.

### Bitstring Status List (`src/vc/statusList.ts` + `statusListRoutes.ts`)

`draft-ietf-oauth-status-list-12`. 1-bit status (0 = valid, 1 = revoked) — the 99% shape; richer 2/4/8-bit states are deferred.

- `createStatusList(size)` / `setCredentialStatus` / `getCredentialStatus` — bit math over a typed `Uint8Array` (consumer owns persistence)
- `signStatusList` / `verifyStatusListJwt` — DEFLATE-compressed bitmap in the `lst` claim, ES256-signed via the OIDC keys infra
- `GET /vc/status/:listId` serves the JWT with the spec `application/statuslist+jwt` content type — re-signs on every fetch so revocations land immediately
- `buildStatusClaim(idx, uri)` — for embedding the status pointer in issued credentials
- Verifier check is **fail-open** per spec §6.1 if the resolver can't fetch (network outage shouldn't reject otherwise-valid creds); revoked-bit-set is fail-closed

### In-mem PresentationRequestStore

Postgres stores still deferred per VC-PLAN.md.

## Tests

426 pass / 0 fail (+16 new in `tests/vpStatusList.test.ts`). Covers: status list bit math (round-trip, JWT sign/verify), OID4VP happy path (issuer→holder→verifier with selective disclosure), four failure modes (missing claims, holder-binding mismatch with attacker key, expired request, unknown request), status list integration (revoked + not-revoked), full HTTP surface round-trip (`POST /vp/authorize → GET /vp/request/:id → POST /vp/response`).

## Backward compat

Fully additive. No existing surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
