### PR TITLE
0.40.0-beta.2 — Postgres VC stores + proof.jwt verification (G6 third slice)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.40.0-beta.1",
+	"version": "0.40.0-beta.2",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -607,6 +607,17 @@ export type {
 } from './vc/openid4vp';
 export { createInMemoryPresentationRequestStore } from './vc/inMemoryVpStores';
 export { vpRoutes, DEFAULT_VP_ROUTE } from './vc/vpRoutes';
+export {
+	createNeonCredentialNonceStore,
+	createNeonCredentialOfferStore,
+	createNeonPresentationRequestStore,
+	createPostgresCredentialNonceStore,
+	createPostgresCredentialOfferStore,
+	createPostgresPresentationRequestStore,
+	vcCredentialNoncesTable,
+	vcCredentialOffersTable,
+	vcPresentationRequestsTable
+} from './vc/postgresVcStores';
 export { createInMemoryScimTokenStore } from './scim/inMemoryScimTokenStore';
 export {
 	createNeonScimTokenStore,

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -49,6 +49,11 @@ import {
 } from '../session/neonStore';
 import { samlServiceProvidersTable } from '../sso/postgresSamlServiceProviderStore';
 import { ssoConnectionsTable } from '../sso/postgresSsoConnectionStore';
+import {
+	vcCredentialNoncesTable,
+	vcCredentialOffersTable,
+	vcPresentationRequestsTable
+} from '../vc/postgresVcStores';
 import { vaultEntriesTable } from '../vault/postgresVaultStore';
 import { webauthnCredentialsTable } from '../webauthn/postgresWebAuthnCredentialStore';
 import { webhookDeliveriesTable } from '../webhooks/postgresStore';
@@ -73,6 +78,7 @@ export type BlockName =
 	| 'sessions'
 	| 'sso'
 	| 'vault'
+	| 'vc'
 	| 'webauthn'
 	| 'webhooks';
 
@@ -128,6 +134,11 @@ export const blockMigrations: Record<BlockName, BlockMigrations> = {
 	]),
 	sso: initMigration('sso', [ssoConnectionsTable, samlServiceProvidersTable]),
 	vault: initMigration('vault', [vaultEntriesTable]),
+	vc: initMigration('vc', [
+		vcCredentialOffersTable,
+		vcCredentialNoncesTable,
+		vcPresentationRequestsTable
+	]),
 	webauthn: initMigration('webauthn', [webauthnCredentialsTable]),
 	webhooks: initMigration('webhooks', [webhookDeliveriesTable])
 };

--- a/src/oidc/vci.ts
+++ b/src/oidc/vci.ts
@@ -255,6 +255,47 @@ const extractHolderJwk = (proofJwt: string) => {
 	} satisfies JsonWebKey;
 };
 
+// Verify the wallet's proof-of-possession JWT (OID4VCI §7.2.1). The JWT MUST:
+//   - be signed by the key in its `header.jwk`
+//   - have `aud === issuer` (the credential issuer URL)
+//   - have a `nonce` claim — when `credentialNonceStore` is configured, the nonce is
+//     consumed from the store (single-use, time-bounded)
+// Returns the holder's JWK on success, undefined otherwise. The cnf binding the issuer
+// bakes into the SD-JWT VC is taken from this verified JWK — so a wallet can't substitute
+// a different key after the fact.
+const verifyProofJwt = async ({
+	config,
+	issuer,
+	now,
+	proofJwt
+}: {
+	config: VciConfig;
+	issuer: string;
+	now: number;
+	proofJwt: string;
+}) => {
+	const holderJwk = extractHolderJwk(proofJwt);
+	if (holderJwk === undefined) return undefined;
+	const decoded = await verifyJwt(proofJwt, holderJwk);
+	if (decoded === undefined) return undefined;
+	const rawPayload = decoded.payload;
+	if (typeof rawPayload !== 'object' || rawPayload === null) return undefined;
+	const payload: { [key: string]: unknown } = { ...rawPayload };
+	if (payload.aud !== issuer) return undefined;
+	if (typeof payload.iat !== 'number') return undefined;
+	// Optional but enforced when configured — replay protection for the proof.
+	if (config.credentialNonceStore !== undefined) {
+		const { nonce } = payload;
+		if (typeof nonce !== 'string') return undefined;
+		const record = await config.credentialNonceStore.consumeNonce(
+			await hashToken(nonce)
+		);
+		if (record === undefined || record.expiresAt < now) return undefined;
+	}
+
+	return holderJwk;
+};
+
 // Issue an SD-JWT VC against an authorized VCI access token. The wallet's proof.jwt (header.jwk)
 // supplies the cnf binding when present.
 export const buildIssuerMetadata = ({
@@ -343,10 +384,15 @@ export const issueCredential = async ({
 	);
 	if (configuration === undefined) return issueFail('invalid_credential_request');
 
-	const holderJwk =
-		input.proofJwt === undefined ? undefined : extractHolderJwk(input.proofJwt);
-	if (input.proofJwt !== undefined && holderJwk === undefined) {
-		return issueFail('invalid_proof');
+	let holderJwk: JsonWebKey | undefined;
+	if (input.proofJwt !== undefined) {
+		holderJwk = await verifyProofJwt({
+			config,
+			issuer,
+			now,
+			proofJwt: input.proofJwt
+		});
+		if (holderJwk === undefined) return issueFail('invalid_proof');
 	}
 
 	const selective = await config.resolveCredentialClaims({

--- a/src/vc/postgresVcStores.ts
+++ b/src/vc/postgresVcStores.ts
@@ -1,0 +1,209 @@
+// Postgres flavors of every VC store: credential offer (VCI), credential nonce (VCI),
+// presentation request (OID4VP). Same Drizzle pattern as the rest of the package — the
+// schema goes into the migrations block automatically via `getTableConfig`.
+//
+// All tables prefixed `auth_vc_*` so they sit alongside `auth_oauth_*` cleanly.
+
+import { eq } from 'drizzle-orm';
+import { bigint, boolean, jsonb, pgTable, varchar } from 'drizzle-orm/pg-core';
+import { type AnyPgDatabase, createNeonDatabase } from '../stores/postgres';
+import type {
+	CredentialNonceRecord,
+	CredentialNonceStore,
+	CredentialOffer,
+	CredentialOfferStore
+} from '../oidc/vci';
+import type {
+	PresentationRequest,
+	PresentationRequestStore
+} from './openid4vp';
+
+const ID_LENGTH = 255;
+
+export const vcCredentialNoncesTable = pgTable('auth_vc_credential_nonces', {
+	expires_at_ms: bigint('expires_at_ms', { mode: 'number' }).notNull(),
+	nonce_hash: varchar('nonce_hash', { length: ID_LENGTH }).primaryKey()
+});
+export const vcCredentialOffersTable = pgTable('auth_vc_credential_offers', {
+	client_id: varchar('client_id', { length: ID_LENGTH }).notNull(),
+	configuration_id: varchar('configuration_id', {
+		length: ID_LENGTH
+	}).notNull(),
+	created_at_ms: bigint('created_at_ms', { mode: 'number' }).notNull(),
+	expires_at_ms: bigint('expires_at_ms', { mode: 'number' }).notNull(),
+	pre_authorized_code_hash: varchar('pre_authorized_code_hash', {
+		length: ID_LENGTH
+	}).primaryKey(),
+	redeemed: boolean('redeemed').notNull(),
+	user_id: varchar('user_id', { length: ID_LENGTH }).notNull()
+});
+export const vcPresentationRequestsTable = pgTable(
+	'auth_vc_presentation_requests',
+	{
+		client_id: varchar('client_id', { length: ID_LENGTH }).notNull(),
+		created_at_ms: bigint('created_at_ms', { mode: 'number' }).notNull(),
+		expected_issuer_jwk_json: jsonb(
+			'expected_issuer_jwk_json'
+		).$type<JsonWebKey>().notNull(),
+		expires_at_ms: bigint('expires_at_ms', { mode: 'number' }).notNull(),
+		nonce: varchar('nonce', { length: ID_LENGTH }).notNull(),
+		request_id: varchar('request_id', { length: ID_LENGTH }).primaryKey(),
+		requested_claims: jsonb('requested_claims').$type<string[]>().notNull(),
+		response_uri: varchar('response_uri', { length: ID_LENGTH }).notNull(),
+		state: varchar('state', { length: ID_LENGTH })
+	}
+);
+
+const toOffer = (
+	row: typeof vcCredentialOffersTable.$inferSelect
+): CredentialOffer => ({
+	clientId: row.client_id,
+	configurationId: row.configuration_id,
+	createdAt: row.created_at_ms,
+	expiresAt: row.expires_at_ms,
+	preAuthorizedCodeHash: row.pre_authorized_code_hash,
+	redeemed: row.redeemed,
+	userId: row.user_id
+});
+
+const toOfferValues = (
+	offer: CredentialOffer
+): typeof vcCredentialOffersTable.$inferInsert => ({
+	client_id: offer.clientId,
+	configuration_id: offer.configurationId,
+	created_at_ms: offer.createdAt,
+	expires_at_ms: offer.expiresAt,
+	pre_authorized_code_hash: offer.preAuthorizedCodeHash,
+	redeemed: offer.redeemed,
+	user_id: offer.userId
+});
+
+const toPresentationRequest = (
+	row: typeof vcPresentationRequestsTable.$inferSelect
+): PresentationRequest => ({
+	clientId: row.client_id,
+	createdAt: row.created_at_ms,
+	expectedIssuerPublicJwk: row.expected_issuer_jwk_json,
+	expiresAt: row.expires_at_ms,
+	nonce: row.nonce,
+	requestedClaims: row.requested_claims,
+	requestId: row.request_id,
+	responseUri: row.response_uri,
+	state: row.state ?? undefined
+});
+
+const toPresentationRequestValues = (
+	request: PresentationRequest
+): typeof vcPresentationRequestsTable.$inferInsert => ({
+	client_id: request.clientId,
+	created_at_ms: request.createdAt,
+	expected_issuer_jwk_json: request.expectedIssuerPublicJwk,
+	expires_at_ms: request.expiresAt,
+	nonce: request.nonce,
+	request_id: request.requestId,
+	requested_claims: request.requestedClaims,
+	response_uri: request.responseUri,
+	state: request.state ?? null
+});
+
+export const createNeonCredentialNonceStore = (databaseUrl: string) =>
+	createPostgresCredentialNonceStore(createNeonDatabase(databaseUrl));
+export const createNeonCredentialOfferStore = (databaseUrl: string) =>
+	createPostgresCredentialOfferStore(createNeonDatabase(databaseUrl));
+export const createNeonPresentationRequestStore = (databaseUrl: string) =>
+	createPostgresPresentationRequestStore(createNeonDatabase(databaseUrl));
+export const createPostgresCredentialNonceStore = (
+	database: AnyPgDatabase
+): CredentialNonceStore => ({
+	consumeNonce: async (nonceHash) => {
+		const rows = await database
+			.select()
+			.from(vcCredentialNoncesTable)
+			.where(eq(vcCredentialNoncesTable.nonce_hash, nonceHash))
+			.limit(1);
+		const [row] = rows;
+		if (row === undefined) return undefined;
+		await database
+			.delete(vcCredentialNoncesTable)
+			.where(eq(vcCredentialNoncesTable.nonce_hash, nonceHash));
+		const record: CredentialNonceRecord = {
+			expiresAt: row.expires_at_ms,
+			nonceHash: row.nonce_hash
+		};
+
+		return record;
+	},
+	saveNonce: async (record) => {
+		await database.insert(vcCredentialNoncesTable).values({
+			expires_at_ms: record.expiresAt,
+			nonce_hash: record.nonceHash
+		});
+	}
+});
+export const createPostgresCredentialOfferStore = (
+	database: AnyPgDatabase
+): CredentialOfferStore => ({
+	consumeOffer: async (preAuthorizedCodeHash) => {
+		const rows = await database
+			.select()
+			.from(vcCredentialOffersTable)
+			.where(
+				eq(
+					vcCredentialOffersTable.pre_authorized_code_hash,
+					preAuthorizedCodeHash
+				)
+			)
+			.limit(1);
+		const [row] = rows;
+		if (row === undefined) return undefined;
+		await database
+			.update(vcCredentialOffersTable)
+			.set({ redeemed: true })
+			.where(
+				eq(
+					vcCredentialOffersTable.pre_authorized_code_hash,
+					preAuthorizedCodeHash
+				)
+			);
+
+		return toOffer(row);
+	},
+	saveOffer: async (offer) => {
+		await database
+			.insert(vcCredentialOffersTable)
+			.values(toOfferValues(offer));
+	}
+});
+export const createPostgresPresentationRequestStore = (
+	database: AnyPgDatabase
+): PresentationRequestStore => ({
+	consumeRequest: async (requestId) => {
+		const rows = await database
+			.select()
+			.from(vcPresentationRequestsTable)
+			.where(eq(vcPresentationRequestsTable.request_id, requestId))
+			.limit(1);
+		const [row] = rows;
+		if (row === undefined) return undefined;
+		await database
+			.delete(vcPresentationRequestsTable)
+			.where(eq(vcPresentationRequestsTable.request_id, requestId));
+
+		return toPresentationRequest(row);
+	},
+	getRequest: async (requestId) => {
+		const rows = await database
+			.select()
+			.from(vcPresentationRequestsTable)
+			.where(eq(vcPresentationRequestsTable.request_id, requestId))
+			.limit(1);
+		const [row] = rows;
+
+		return row === undefined ? undefined : toPresentationRequest(row);
+	},
+	saveRequest: async (request) => {
+		await database
+			.insert(vcPresentationRequestsTable)
+			.values(toPresentationRequestValues(request));
+	}
+});

--- a/tests/vci.test.ts
+++ b/tests/vci.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
-import { generateSigningKey } from '../src/oidc/keys';
+import { generateSigningKey, signJwt, type SigningKey } from '../src/oidc/keys';
 import {
 	createInMemoryCredentialNonceStore,
 	createInMemoryCredentialOfferStore
@@ -22,6 +22,64 @@ const ISSUER = 'https://issuer.example';
 const HTTP_OK = 200;
 const HTTP_BAD_REQUEST = 400;
 const HTTP_UNAUTHORIZED = 401;
+
+// Helper: wallet builds a proof-of-possession JWT over the c_nonce + audience using its
+// holder key. The package's verifier enforces the header.jwk matches the signing key, the
+// aud matches the credential issuer, and the nonce was minted by the server.
+const buildHolderProofJwt = async ({
+	audience,
+	holderKey,
+	nonce
+}: {
+	audience: string;
+	holderKey: SigningKey;
+	nonce: string;
+}) => {
+	// We need a header that includes `jwk`. signJwt builds its own header (alg/kid/typ); for
+	// OID4VCI proof we want the wallet's public JWK embedded so the issuer knows what to
+	// verify against. Construct the JWT manually here.
+	const msPerSecond = 1000;
+	const header: {
+		alg: string;
+		jwk: JsonWebKey;
+		kid: string;
+		typ: string;
+	} = {
+		alg: 'ES256',
+		jwk: holderKey.publicJwk,
+		kid: holderKey.kid,
+		typ: 'openid4vci-proof+jwt'
+	};
+	const payload: { aud: string; iat: number; nonce: string } = {
+		aud: audience,
+		iat: Math.floor(Date.now() / msPerSecond),
+		nonce
+	};
+	const headerSegment = Buffer.from(JSON.stringify(header)).toString('base64url');
+	const payloadSegment = Buffer.from(JSON.stringify(payload)).toString('base64url');
+	const signingInput = `${headerSegment}.${payloadSegment}`;
+	// We sign by going through signJwt then swapping its header for ours — the WebCrypto
+	// signature is over the {header}.{payload} string, so we have to compute it with our
+	// custom header. Implement a thin custom signer using the same crypto primitives signJwt
+	// uses internally.
+	const cryptoKey = await crypto.subtle.importKey(
+		'jwk',
+		holderKey.privateJwk,
+		{ name: 'ECDSA', namedCurve: 'P-256' },
+		false,
+		['sign']
+	);
+	const signature = new Uint8Array(
+		await crypto.subtle.sign(
+			{ hash: 'SHA-256', name: 'ECDSA' },
+			cryptoKey,
+			new TextEncoder().encode(signingInput)
+		)
+	);
+
+	return `${signingInput}.${Buffer.from(signature).toString('base64url')}`;
+};
+void signJwt;
 
 const buildConfig = (signingKey: Awaited<ReturnType<typeof generateSigningKey>>) => {
 	const credentialOfferStore = createInMemoryCredentialOfferStore();
@@ -106,7 +164,7 @@ describe('OpenID4VCI pre-authorized_code flow (end-to-end)', () => {
 		});
 	});
 
-	test('binds the credential to the wallet key when proof.jwt is supplied', async () => {
+	test('binds the credential to the wallet key when proof.jwt verifies', async () => {
 		const signingKey = await generateSigningKey();
 		const holderKey = await generateSigningKey();
 		const { config, credentialOfferStore } = buildConfig(signingKey);
@@ -124,14 +182,17 @@ describe('OpenID4VCI pre-authorized_code flow (end-to-end)', () => {
 		});
 		expect(exchange.ok).toBe(true);
 		if (!exchange.ok) return;
+		const cNonce = exchange.c_nonce;
+		expect(cNonce).toBeDefined();
+		if (cNonce === undefined) return;
 
-		// Fake proof.jwt — header.jwk carries the holder's public key; the issuer reads it for
-		// cnf binding and doesn't verify the JWT signature in this slice (proof verification is a
-		// deferred step listed in VC-PLAN.md).
-		const header = Buffer.from(
-			JSON.stringify({ alg: 'ES256', jwk: holderKey.publicJwk, typ: 'openid4vci-proof+jwt' })
-		).toString('base64url');
-		const proofJwt = `${header}.payload.signature`;
+		// Real proof.jwt — wallet signs over the c_nonce + audience with its private key.
+		// The package now verifies the proof signature + nonce + audience before honoring cnf.
+		const proofJwt = await buildHolderProofJwt({
+			audience: ISSUER,
+			holderKey,
+			nonce: cNonce
+		});
 
 		const credential = await issueCredential({
 			config,
@@ -147,6 +208,86 @@ describe('OpenID4VCI pre-authorized_code flow (end-to-end)', () => {
 			token: credential.credential
 		});
 		expect(verified?.cnf?.jwk.x).toBe(holderKey.publicJwk.x);
+	});
+
+	test('rejects a proof.jwt signed with a key other than its header.jwk', async () => {
+		const signingKey = await generateSigningKey();
+		const realHolderKey = await generateSigningKey();
+		const attackerKey = await generateSigningKey();
+		const { config, credentialOfferStore } = buildConfig(signingKey);
+		const { preAuthorizedCode } = await createCredentialOffer({
+			clientId: 'wallet.example',
+			configurationId: 'identity_v1',
+			store: credentialOfferStore,
+			userId: 'user-123'
+		});
+		const exchange = await exchangePreAuthorizedCode({
+			config,
+			issuer: ISSUER,
+			preAuthorizedCode,
+			signingKey
+		});
+		if (!exchange.ok) throw new Error('exchange failed');
+		const cNonce = exchange.c_nonce;
+		if (cNonce === undefined) throw new Error('no c_nonce');
+		// Header claims realHolderKey's public JWK but the JWT is signed by attackerKey —
+		// signature verification against the header.jwk will fail.
+		const { generateSigningKey: gen, signJwt } = await import('../src/oidc/keys');
+		void gen;
+		const forgedHeader = Buffer.from(
+			JSON.stringify({
+				alg: 'ES256',
+				jwk: realHolderKey.publicJwk,
+				kid: attackerKey.kid,
+				typ: 'openid4vci-proof+jwt'
+			})
+		).toString('base64url');
+		const forgedSigned = await signJwt(
+			{ aud: ISSUER, iat: Math.floor(Date.now() / 1000), nonce: cNonce },
+			attackerKey
+		);
+		const [, payload, signature] = forgedSigned.split('.');
+		const proofJwt = `${forgedHeader}.${payload}.${signature}`;
+		const result = await issueCredential({
+			config,
+			input: { accessToken: exchange.access_token, proofJwt },
+			issuer: ISSUER,
+			signingKey
+		});
+		expect(result).toEqual({ error: 'invalid_proof', ok: false });
+	});
+
+	test('rejects a proof.jwt with the wrong audience', async () => {
+		const signingKey = await generateSigningKey();
+		const holderKey = await generateSigningKey();
+		const { config, credentialOfferStore } = buildConfig(signingKey);
+		const { preAuthorizedCode } = await createCredentialOffer({
+			clientId: 'wallet.example',
+			configurationId: 'identity_v1',
+			store: credentialOfferStore,
+			userId: 'user-123'
+		});
+		const exchange = await exchangePreAuthorizedCode({
+			config,
+			issuer: ISSUER,
+			preAuthorizedCode,
+			signingKey
+		});
+		if (!exchange.ok) throw new Error('exchange failed');
+		const cNonce = exchange.c_nonce;
+		if (cNonce === undefined) throw new Error('no c_nonce');
+		const proofJwt = await buildHolderProofJwt({
+			audience: 'https://wrong-issuer.example',
+			holderKey,
+			nonce: cNonce
+		});
+		const result = await issueCredential({
+			config,
+			input: { accessToken: exchange.access_token, proofJwt },
+			issuer: ISSUER,
+			signingKey
+		});
+		expect(result).toEqual({ error: 'invalid_proof', ok: false });
 	});
 
 	test('rejects a redeemed pre-authorized_code on second use', async () => {


### PR DESCRIPTION
## What

**G6 third slice — production readiness before promoting 0.40.0 stable.** Two items from `VC-PLAN.md`:

### Postgres VC stores (`src/vc/postgresVcStores.ts`)

Production-grade persistence for every VC store. Same Drizzle pattern as the rest of the package; the schema goes into the migrations block automatically via `getTableConfig`.

- `createPostgresCredentialOfferStore` + `createNeonCredentialOfferStore` → `auth_vc_credential_offers`
- `createPostgresCredentialNonceStore` + `createNeonCredentialNonceStore` → `auth_vc_credential_nonces`
- `createPostgresPresentationRequestStore` + `createNeonPresentationRequestStore` → `auth_vc_presentation_requests`
- Wired into migrations block under `'vc'` BlockName so `bunx absolute-auth migrate --blocks vc` creates them

### Real `proof.jwt` signature verification in `issueCredential`

beta.0 read the wallet's `header.jwk` for cnf binding but didn't verify the JWT signature. That gap is now closed. `verifyProofJwt` enforces:

- **JWT signature verifies against `header.jwk`** — wallet can't substitute keys after the fact
- **`aud === issuer`** — prevents the confused-deputy attack where a proof minted for one issuer is replayed against another
- **`iat` present**
- **When `credentialNonceStore` is configured**: `nonce` claim must match a `c_nonce` that was issued and not yet consumed (single-use, time-bounded; consumed at proof verification)

The cnf binding baked into the issued SD-JWT VC now reflects the proof-verified key, not just a claimed header.

## Tests

428 pass / 0 fail. Two new tests cover the proof verification failure modes:
- **Forged signer rejected** — header claims one JWK but the JWT is signed by a different key
- **Wrong audience rejected** — proof claims the wrong issuer URL

The existing cnf-binding test was upgraded from "fake proof" to a real signed proof JWT against the issued c_nonce.

## Backward compat

- New optional Postgres stores — opt-in
- Proof verification: **breaking-but-correct** for any consumer that was passing an unsigned/fake proof.jwt (which would have been broken at presentation time anyway because the verifier checks `cnf.jwk` against the kb_jwt signature). Real wallets always sign proof.jwt with their key.

After this slice, ready to promote to stable `0.40.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verifiable credentials (VC) storage support for Postgres and Neon databases, including credential nonces, offers, and presentation requests.
  * Implemented proof JWT verification for credential issuance with nonce validation and audience binding.

* **Chores**
  * Bumped package version to 0.40.0-beta.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/absolutejs/absolute-auth/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->