### PR TITLE
feat: OIDC conformance prep — Form Post + RFC 9207 (0.41.0)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"558c85a4-9fc0-47ac-9153-cfc7e1534a49","pid":10469,"procStart":"121582","acquiredAt":1779887012777}

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,70 @@
+# OpenID Conformance Suite — local runner
+
+Runs the OpenID Foundation conformance suite
+(<https://gitlab.com/openid/conformance-suite>) against a deployed
+`@absolutejs/auth` OIDC provider. Nothing here is needed to use the package;
+this directory is purely the certification preparation harness.
+
+The conformance suite is a JVM application (Spring Boot + MongoDB + httpd)
+distributed via Docker. Running it locally requires Docker + ~3 GB RAM. It
+is **not bundled with the package** — the runner script clones it
+on-demand into a sibling directory.
+
+## Quick start
+
+```bash
+# 1. one-time prep: clone + build the suite (15-20 min, mostly Maven downloads)
+./conformance/setup.sh
+
+# 2. point at any URL that serves a `@absolutejs/auth` discovery document
+TARGET_ISSUER=https://oidc-conformance.absolutejs.com ./conformance/run.sh
+
+# 3. browse results: http://localhost:8443/
+#    Default credentials: ssl/ca, see suite docs
+```
+
+For a fully local round-trip (suite + provider on the same machine), use
+`ngrok` or `cloudflared` to expose the local provider over a real HTTPS URL
+— the conformance suite refuses to talk to `http://localhost`.
+
+## Profiles we target
+
+The package targets the **minimum honest OIDC badge set** at
+<https://openid.net/certification/op_servers/>:
+
+| Profile | OpenID profile name | Status |
+|---|---|---|
+| Basic OP | `oidcc-basic-certification-test-plan` | ready (with this PR's `response_mode=form_post`) |
+| Config OP | `oidcc-config-certification-test-plan` | ready |
+| Dynamic OP | `oidcc-dynamic-certification-test-plan` | ready (DCR shipped in 0.29.0) |
+| RP-Init Logout OP | `oidcc-rp-initiated-logout-certification-test-plan` | ready (0.29.0) |
+| Back-Channel Logout OP | `oidcc-backchannel-rp-initiated-logout-certification-test-plan` | ready (0.29.0) |
+| Form Post OP | `oidcc-formpost-basic-certification-test-plan` | ready (this PR) |
+
+Aspirational (FAPI 2.0) profiles are documented in
+`../OPENID-CONFORMANCE-CERTIFICATION.md`; running those needs CIBA + the
+extra signing-alg policy work that ship in `@absolutejs/auth` 0.36.0+ +
+some additional configuration the suite expects.
+
+## Where the suite expects to land
+
+The suite needs a **reachable HTTPS URL** with at least these endpoints
+working against a published, registered test client:
+
+- `GET /.well-known/openid-configuration`
+- `GET /oauth2/jwks`
+- `POST /oauth2/register` (Dynamic OP)
+- `GET /oauth2/authorize` (with `response_mode=form_post` support for Form Post OP)
+- `POST /oauth2/token`
+- `GET /oauth2/userinfo`
+- `GET /oauth2/end-session` (RP-Init Logout OP)
+- `POST /oauth2/backchannel-logout` (Back-Channel Logout OP)
+
+`examples/auth` in `~/abs/examples` runs every block enabled by default,
+so it can serve as the reference instance.
+
+## Once we're funded
+
+See `../OPENID-CONFORMANCE-CERTIFICATION.md` for the OpenID Foundation
+membership + per-profile fee schedule and the submission process. The
+self-test results from this directory feed directly into the submission.

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Boots the OpenID conformance suite via docker-compose, against a target
+# issuer URL passed in via TARGET_ISSUER. The suite UI is served on
+# https://localhost:8443; results land in MongoDB inside the compose stack
+# (persists across runs unless you `docker-compose down -v`).
+#
+# Prerequisites:
+#   1. ./conformance/setup.sh has run (clones + builds the suite)
+#   2. TARGET_ISSUER points at a reachable HTTPS URL that serves
+#      /.well-known/openid-configuration
+#   3. Docker daemon is up
+set -euo pipefail
+
+SUITE_DIR="${SUITE_DIR:-$HOME/abs/conformance-suite}"
+TARGET_ISSUER="${TARGET_ISSUER:-}"
+
+if [ -z "$TARGET_ISSUER" ]; then
+	echo "[run] error: set TARGET_ISSUER, e.g.:" >&2
+	echo "      TARGET_ISSUER=https://oidc-conformance.absolutejs.com ./conformance/run.sh" >&2
+	exit 1
+fi
+
+if [ ! -d "$SUITE_DIR" ]; then
+	echo "[run] error: $SUITE_DIR does not exist; run ./conformance/setup.sh first" >&2
+	exit 1
+fi
+
+echo "[run] target: $TARGET_ISSUER"
+echo "[run] sanity-check the discovery doc is reachable…"
+if ! curl -fsSLI "$TARGET_ISSUER/.well-known/openid-configuration" >/dev/null; then
+	echo "[run] error: $TARGET_ISSUER/.well-known/openid-configuration is unreachable" >&2
+	exit 1
+fi
+echo "[run] ✓ discovery reachable"
+
+cd "$SUITE_DIR"
+
+echo "[run] starting docker-compose stack…"
+docker compose up -d
+
+echo
+echo "[run] ✓ suite is up at https://localhost:8443"
+echo
+echo "Next:"
+echo "  1. open https://localhost:8443/ (accept the self-signed cert)"
+echo "  2. create a test plan from the catalog, e.g.:"
+echo "       oidcc-basic-certification-test-plan"
+echo "       oidcc-formpost-basic-certification-test-plan"
+echo "       oidcc-config-certification-test-plan"
+echo "       oidcc-dynamic-certification-test-plan"
+echo "       oidcc-rp-initiated-logout-certification-test-plan"
+echo "  3. set 'discoveryUrl' = $TARGET_ISSUER/.well-known/openid-configuration"
+echo "  4. run the plan; the suite walks the OP through ~50-150 test cases"
+echo
+echo "To stop:    docker compose -f $SUITE_DIR/docker-compose.yml down"
+echo "Wipe data:  docker compose -f $SUITE_DIR/docker-compose.yml down -v"

--- a/conformance/setup.sh
+++ b/conformance/setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# One-time setup: clone + build the OpenID conformance suite into a sibling
+# directory. Idempotent — safe to re-run.
+#
+# The suite lives at ~/abs/conformance-suite (NOT inside ~/abs/auth so it
+# doesn't pollute the package's build / lint / publish). The runner script
+# (run.sh) finds it via this fixed path.
+set -euo pipefail
+
+SUITE_DIR="${SUITE_DIR:-$HOME/abs/conformance-suite}"
+SUITE_REPO="https://gitlab.com/openid/conformance-suite.git"
+
+if [ ! -d "$SUITE_DIR" ]; then
+	echo "[setup] cloning $SUITE_REPO → $SUITE_DIR"
+	git clone --depth=1 "$SUITE_REPO" "$SUITE_DIR"
+else
+	echo "[setup] $SUITE_DIR already exists; pulling latest"
+	git -C "$SUITE_DIR" pull --ff-only
+fi
+
+cd "$SUITE_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "[setup] error: docker is required" >&2
+	exit 1
+fi
+
+# The suite has its own Maven Docker build target. ~15-20 min on a cold cache.
+echo "[setup] building suite via mvn-docker (this can take 15+ min)…"
+docker run --rm \
+	-v "$SUITE_DIR":/usr/src/mymaven \
+	-v "$HOME/.m2":/root/.m2 \
+	-w /usr/src/mymaven \
+	maven:3.9-eclipse-temurin-17 \
+	mvn -B clean package -DskipTests
+
+echo "[setup] done. Next step: ./conformance/run.sh"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.40.0",
+	"version": "0.41.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/oidc/routes.ts
+++ b/src/oidc/routes.ts
@@ -93,6 +93,66 @@ const tokenResponse = (tokens: TokenSet) => jsonResponse(tokens, HTTP_OK);
 const redirectTo = (url: string) =>
 	new Response(null, { headers: { location: url }, status: HTTP_FOUND });
 
+// HTML-escape the four characters that change meaning inside an HTML attribute
+// value. The form_post response_mode renders untrusted parameter values
+// (state, code, error, error_description) into <input value="..."> attrs.
+const escapeHtmlAttr = (value: string) =>
+	value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;');
+
+// OAuth 2.0 Form Post Response Mode (openid.net/specs/oauth-v2-form-post-response-mode-1_0.html).
+// Renders an auto-submitting HTML form POSTing the response parameters to the
+// client's redirect_uri, instead of the default `?param=…` GET redirect. Used
+// by clients that pass `response_mode=form_post` to /authorize — the typical
+// motivation is keeping large response payloads out of the URL or browser
+// history when the client can't accept fragment/query delivery.
+const formPostResponse = (
+	redirectUri: string,
+	params: Record<string, string>
+) => {
+	const inputs = Object.entries(params)
+		.map(
+			([name, value]) =>
+				`<input type="hidden" name="${escapeHtmlAttr(name)}" value="${escapeHtmlAttr(value)}" />`
+		)
+		.join('');
+	const body =
+		`<!DOCTYPE html><html><head><meta charset="utf-8" />` +
+		`<title>Submitting…</title></head>` +
+		`<body onload="document.forms[0].submit()">` +
+		`<form method="post" action="${escapeHtmlAttr(redirectUri)}">${inputs}` +
+		`<noscript><button type="submit">Continue</button></noscript>` +
+		`</form></body></html>`;
+
+	return new Response(body, {
+		headers: {
+			'cache-control': 'no-store',
+			'content-type': 'text/html;charset=UTF-8'
+		},
+		status: HTTP_OK
+	});
+};
+
+// Dispatch an /authorize response to the client according to its
+// `response_mode`. Only the success / error pair: both routes use this so
+// `?error=…` and `?code=…` go via the same channel (the spec requires it —
+// you can't return a code via form_post and the error via query).
+const respondToClient = (
+	redirectUri: string,
+	responseMode: string,
+	params: Record<string, string>
+) => {
+	if (responseMode === 'form_post') {
+		return formPostResponse(redirectUri, params);
+	}
+	const search = new URLSearchParams(params);
+
+	return redirectTo(`${redirectUri}?${search.toString()}`);
+};
+
 // RFC 6749 §2.3.1 HTTP Basic client credentials.
 const readBasicAuth = (authorization: string | undefined) => {
 	if (
@@ -556,6 +616,8 @@ export const oidcProviderRoutes = <UserType>(
 		request_object_signing_alg_values_supported: ['ES256'],
 		request_parameter_supported: true,
 		require_signed_request_object_supported: true,
+		authorization_response_iss_parameter_supported: true,
+		response_modes_supported: ['query', 'form_post'],
 		response_types_supported: ['code'],
 		revocation_endpoint: `${issuer}${revokeRoute}`,
 		subject_types_supported: ['public'],
@@ -747,6 +809,7 @@ export const oidcProviderRoutes = <UserType>(
 					code_challenge_method: codeChallengeMethod,
 					nonce,
 					redirect_uri: redirectUri,
+					response_mode: requestedResponseMode,
 					response_type: responseType,
 					scope,
 					state
@@ -765,11 +828,30 @@ export const oidcProviderRoutes = <UserType>(
 					);
 				}
 
-				const errorRedirect = (error: string) => {
-					const params = new URLSearchParams({ error });
-					if (state !== undefined) params.set('state', state);
+				// Default response_mode follows the spec: 'query' for
+				// response_type=code (what we support). 'form_post' is opt-in
+				// via the query param.
+				const responseMode =
+					requestedResponseMode === 'form_post' ? 'form_post' : 'query';
+				if (
+					requestedResponseMode !== undefined &&
+					requestedResponseMode !== 'query' &&
+					requestedResponseMode !== 'form_post'
+				) {
+					return jsonResponse(
+						{ error: 'unsupported_response_mode' },
+						HTTP_BAD_REQUEST
+					);
+				}
 
-					return redirectTo(`${redirectUri}?${params.toString()}`);
+				const errorRedirect = (error: string) => {
+					// RFC 9207 — include the issuer identifier so RPs can
+					// detect mix-up attacks where another authorization
+					// server's response is redirected to them.
+					const params: Record<string, string> = { error, iss: issuer };
+					if (state !== undefined) params.state = state;
+
+					return respondToClient(redirectUri, responseMode, params);
 				};
 				// FAPI hardening: clients that opted into PAR-only can't sneak in via a
 				// plain /authorize call — must have come through the PAR path above (which
@@ -930,10 +1012,14 @@ export const oidcProviderRoutes = <UserType>(
 					userId: getUserId(userSession.user)
 				});
 
-				const params = new URLSearchParams({ code });
-				if (state !== undefined) params.set('state', state);
+				const params: Record<string, string> = {
+					code,
+					// RFC 9207 — mix-up attack defense.
+					iss: issuer
+				};
+				if (state !== undefined) params.state = state;
 
-				return redirectTo(`${redirectUri}?${params.toString()}`);
+				return respondToClient(redirectUri, responseMode, params);
 			},
 			{
 				cookie: t.Cookie({
@@ -952,6 +1038,7 @@ export const oidcProviderRoutes = <UserType>(
 					redirect_uri: t.Optional(t.String()),
 					request: t.Optional(t.String()),
 					request_uri: t.Optional(t.String()),
+					response_mode: t.Optional(t.String()),
 					response_type: t.Optional(t.String()),
 					scope: t.Optional(t.String()),
 					state: t.Optional(t.String())

--- a/tests/oidcProvider.test.ts
+++ b/tests/oidcProvider.test.ts
@@ -246,6 +246,101 @@ describe('OIDC provider', () => {
 		expect(reuse.status).toBe(400);
 	});
 
+	test('authorization response carries RFC 9207 iss parameter (mix-up defense)', async () => {
+		const challenge = await hashToken(VERIFIER);
+		const redirect = await authorize(
+			app,
+			challenge,
+			`user_session_id=${SESSION_ID}`
+		);
+		expect(redirect.status).toBe(302);
+		const location = redirect.headers.get('location') ?? '';
+		const url = new URL(location);
+		expect(url.searchParams.get('iss')).toBe(ISSUER);
+		// Error responses also carry iss — exercise via unsupported_response_type.
+		const badParams = new URLSearchParams({
+			client_id: 'app1',
+			code_challenge: challenge,
+			code_challenge_method: 'S256',
+			redirect_uri: REDIRECT_URI,
+			response_type: 'token',
+			scope: 'openid',
+			state: 'state-err'
+		});
+		const errorResponse = await app.handle(
+			new Request(
+				`http://localhost/oauth2/authorize?${badParams.toString()}`,
+				{ headers: { cookie: `user_session_id=${SESSION_ID}` } }
+			)
+		);
+		expect(errorResponse.status).toBe(302);
+		const errorUrl = new URL(errorResponse.headers.get('location') ?? '');
+		expect(errorUrl.searchParams.get('error')).toBe(
+			'unsupported_response_type'
+		);
+		expect(errorUrl.searchParams.get('iss')).toBe(ISSUER);
+	});
+
+	test('form_post response_mode returns auto-submitting HTML with code + state', async () => {
+		const challenge = await hashToken(VERIFIER);
+		const params = new URLSearchParams({
+			client_id: 'app1',
+			code_challenge: challenge,
+			code_challenge_method: 'S256',
+			nonce: 'nonce-fp',
+			redirect_uri: REDIRECT_URI,
+			response_mode: 'form_post',
+			response_type: 'code',
+			scope: 'openid',
+			state: 'state-fp"with-quote'
+		});
+		const response = await app.handle(
+			new Request(`http://localhost/oauth2/authorize?${params.toString()}`, {
+				headers: { cookie: `user_session_id=${SESSION_ID}` }
+			})
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toContain('text/html');
+		const html = await response.text();
+		// Auto-submit shell
+		expect(html).toContain('<form method="post"');
+		expect(html).toContain(`action="${REDIRECT_URI}"`);
+		expect(html).toContain('document.forms[0].submit()');
+		// State is HTML-attribute escaped (`"` → `&quot;`)
+		expect(html).toContain(
+			'name="state" value="state-fp&quot;with-quote"'
+		);
+		// code is present + non-empty
+		const codeMatch = html.match(/name="code" value="([^"]+)"/);
+		expect(codeMatch).not.toBeNull();
+		expect((codeMatch?.[1] ?? '').length).toBeGreaterThan(0);
+	});
+
+	test('unsupported response_mode is rejected with invalid_request error code', async () => {
+		const challenge = await hashToken(VERIFIER);
+		const params = new URLSearchParams({
+			client_id: 'app1',
+			code_challenge: challenge,
+			code_challenge_method: 'S256',
+			nonce: 'nonce-bad-mode',
+			redirect_uri: REDIRECT_URI,
+			response_mode: 'fragment',
+			response_type: 'code',
+			scope: 'openid',
+			state: 'state-bad'
+		});
+		const response = await app.handle(
+			new Request(`http://localhost/oauth2/authorize?${params.toString()}`, {
+				headers: { cookie: `user_session_id=${SESSION_ID}` }
+			})
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe('unsupported_response_mode');
+	});
+
 	test('discovery + jwks describe the provider', async () => {
 		const discovery = await (
 			await app.handle(
@@ -255,6 +350,10 @@ describe('OIDC provider', () => {
 		expect(discovery.issuer).toBe(ISSUER);
 		expect(discovery.code_challenge_methods_supported).toContain('S256');
 		expect(discovery.dpop_signing_alg_values_supported).toContain('ES256');
+		expect(discovery.response_modes_supported).toEqual(['query', 'form_post']);
+		expect(discovery.authorization_response_iss_parameter_supported).toBe(
+			true
+		);
 
 		const jwks = await (
 			await app.handle(new Request('http://localhost/oauth2/jwks'))


### PR DESCRIPTION
Engineering prep for the OpenID Conformance Certification (deferred until budget — see `OPENID-CONFORMANCE-CERTIFICATION.md`). Two spec additions + a local-run harness.

## Form Post Response Mode (OAuth 2.0 Form Post 1.0)

Closes the gap for the minimum honest OP certification set (Basic + Config + Dynamic + RP-Init Logout + Back-Channel Logout + Form Post). With `response_mode=form_post` the OP returns an auto-submitting HTML form POSTing `code` + `state` (+ `iss`) to `redirect_uri` instead of redirecting via 302 + query params.

Untrusted values are HTML-attribute escaped. `<noscript>` fallback button included. Unsupported response_mode values return `unsupported_response_mode`.

## RFC 9207 Authorization Server Issuer Identification

`iss=<issuer>` on every authorize response (success + error, query + form_post). Mix-up attack defense — required for FAPI 2.0 baseline and checked by the conformance suite.

## conformance/

- `README.md` — profile-by-profile readiness, gates
- `setup.sh` — clones the OpenID Foundation suite + builds via Maven-in-Docker
- `run.sh` — boots the suite against any `TARGET_ISSUER` URL

## Verified

- 431/431 tests pass (3 new in `oidcProvider.test.ts`)
- `absolute typecheck` clean
- `bun run build` clean

## Bump

0.40.0 → 0.41.0. Additive only; existing `response_mode=query` behavior unchanged (just now carries an extra `iss` param — spec-required for RPs to either verify or ignore).