### PR TITLE
feat: trust-builders bundle (0.42.0) — strictFapi + type matrix + Lucia + OAuth quirks

### DIFF
--- a/conformance/setup.sh
+++ b/conformance/setup.sh
@@ -31,7 +31,7 @@ docker run --rm \
 	-v "$SUITE_DIR":/usr/src/mymaven \
 	-v "$HOME/.m2":/root/.m2 \
 	-w /usr/src/mymaven \
-	maven:3.9-eclipse-temurin-17 \
+	maven:3.9-eclipse-temurin-21 \
 	mvn -B clean package -DskipTests
 
 echo "[setup] done. Next step: ./conformance/run.sh"

--- a/docs/MIGRATE-FROM-LUCIA.md
+++ b/docs/MIGRATE-FROM-LUCIA.md
@@ -1,0 +1,215 @@
+# Migrating from Lucia (v3) to `@absolutejs/auth`
+
+Lucia was deprecated in 2024. The maintainer's note —
+*"database adapters have been a significant complexity tax"* — is exactly
+the problem `@absolutejs/auth` solves by **owning the schema** (via
+Drizzle migrations + the `bunx absolute-auth migrate` CLI) instead of
+abstracting around yours.
+
+If you're on Lucia v3, this guide walks you through the migration
+end-to-end. It assumes Postgres + Drizzle ORM; SQLite + better-sqlite3
+follow the same flow with the obvious column-type swaps.
+
+> Status: tested against Lucia v3.2.x. Open an issue with your Lucia
+> config snippet if you hit a shape this guide doesn't cover.
+
+## What you keep
+
+- **Your user table** — `@absolutejs/auth` doesn't rename `users.id`,
+  drop fields, or require you to give up your domain columns. The
+  migration adds `users.sub` (UUID) alongside whatever you already have.
+- **Session semantics** — server-side sessions with an httpOnly cookie,
+  same trust model as Lucia. We use Redis or in-memory; the cookie name
+  is `user_session_id` (configurable).
+- **Argon2id password hashes** — Lucia's default. We accept them
+  unchanged (`@absolutejs/auth` uses `Bun.password.hash` which also
+  defaults to argon2id).
+
+## What changes
+
+| Lucia | `@absolutejs/auth` |
+|---|---|
+| `lucia.createSession(userId, attributes)` | Implicit — `auth<UserType>()` creates the session on a successful OAuth callback or `signin.email({...})`. |
+| `lucia.validateSession(sessionId)` | Use the `protectRoutePlugin` decorator on routes that need an authenticated user. |
+| `lucia.invalidateSession(sessionId)` | `await authSessionStore.removeSession(sessionId)` or hit `/oauth2/signout`. |
+| `lucia.invalidateUserSessions(userId)` | `await authSessionStore.removeUserSessions(userId)`. |
+| `getUserAttributes` hook | Move logic into your route handler; the user is already in `context.user`. |
+| Custom `Adapter` (SQLite / Postgres / D1) | Not needed — schema is fixed via Drizzle migrations. |
+| `Lucia.Register` module-augmentation trick | Plain generic — `auth<MyUser>({...})`. |
+
+## Step-by-step
+
+### 1. Install + bootstrap
+
+```bash
+bun add @absolutejs/auth elysia citra
+bunx absolute-auth migrate
+```
+
+The CLI generates the Drizzle migrations for `users`, `auth_identities`,
+`auth_sessions`, `auth_login_history` (adaptive risk), and so on. Run
+them against your DB.
+
+### 2. Backfill from Lucia's tables
+
+Lucia v3 has `user`, `session`, and `key` (or `oauth_account` depending
+on your adapter setup). Migrate each row:
+
+```ts
+// scripts/migrateFromLucia.ts
+import { neon } from '@neondatabase/serverless';
+
+const sql = neon(process.env.DATABASE_URL);
+
+// 1. Users — Lucia's `user` → @absolutejs/auth's `users`
+//    Generate fresh UUIDs for `sub`; keep your existing primary key
+//    aliased in `legacy_id` for downstream-FK rewrites if needed.
+await sql`
+  INSERT INTO users (sub, email, created_at, /* your fields */)
+  SELECT
+    gen_random_uuid()::text,
+    email,
+    COALESCE(created_at, NOW()),
+    /* your fields */
+  FROM lucia_user
+  ON CONFLICT (email) DO NOTHING
+`;
+
+// 2. OAuth identities — Lucia's `key` rows with `:` prefix
+//    (e.g. `google:1234567890`) → auth_identities
+await sql`
+  INSERT INTO auth_identities (id, auth_provider, provider_subject, user_sub)
+  SELECT
+    split_part(k.id, ':', 1) || ':' || split_part(k.id, ':', 2),
+    split_part(k.id, ':', 1),
+    split_part(k.id, ':', 2),
+    u.sub
+  FROM lucia_key k
+  JOIN lucia_user l ON l.id = k.user_id
+  JOIN users u ON u.email = l.email
+  WHERE k.id LIKE '%:%'
+  ON CONFLICT DO NOTHING
+`;
+
+// 3. Password hashes — Lucia's `key` with `hashed_password`
+//    Argon2id format carries over unchanged.
+await sql`
+  UPDATE users SET password = k.hashed_password
+  FROM lucia_key k
+  JOIN lucia_user l ON l.id = k.user_id
+  WHERE k.hashed_password IS NOT NULL
+    AND users.email = l.email
+`;
+
+// 4. Sessions — DON'T migrate. Lucia uses opaque IDs; we use a different
+//    cookie name + scheme. Force a re-login on cutover by NOT copying
+//    the session table.
+```
+
+### 3. Wire the new auth config
+
+```ts
+import { Elysia } from 'elysia';
+import { auth, createNeonAuthSessionStore } from '@absolutejs/auth';
+
+type MyUser = {
+  email: string;
+  sub: string;
+  // …whatever your domain user has
+};
+
+const authSessionStore = createNeonAuthSessionStore<MyUser>();
+
+const app = await auth<MyUser>({
+  authSessionStore,
+  // your existing OAuth provider config (Google, GitHub, …)
+  providersConfiguration: { google: { /* … */ } },
+  // The bridge from a decoded token → your user shape.
+  // Lucia's `getUserAttributes` lives here now.
+  getUser: (decoded) => ({
+    email: decoded.email,
+    sub: /* … */,
+  }),
+});
+```
+
+### 4. Replace `validateSession` call sites
+
+Before (Lucia):
+
+```ts
+app.get('/me', async (ctx) => {
+  const { session, user } = await lucia.validateSession(
+    ctx.cookies.get('auth_session') ?? ''
+  );
+  if (!session) return ctx.error(401);
+
+  return user;
+});
+```
+
+After (`@absolutejs/auth`):
+
+```ts
+import { protectRoutePlugin } from '@absolutejs/auth';
+
+app
+  .use(protectRoutePlugin<MyUser>())
+  .get('/me', ({ user }) => user); // typed as MyUser, throws 401 if unauthenticated
+```
+
+### 5. Switch the cookie name (optional)
+
+Lucia's default cookie is `auth_session`. `@absolutejs/auth` uses
+`user_session_id`. If you want zero re-logins after the cutover (you
+also can't — see Step 2 — but if you've decided to migrate sessions
+manually), the session cookie config is overridable. We recommend
+NOT migrating sessions; the cutover is the right moment to force
+re-auth.
+
+### 6. Drop the Lucia tables
+
+```sql
+DROP TABLE lucia_session, lucia_key, lucia_user;
+```
+
+(After the migration script verifies zero new user creation in Lucia.)
+
+## What you get post-migration that you didn't have before
+
+- **OIDC provider role** — your app can issue OAuth tokens to other apps
+  via `/.well-known/openid-configuration`. Lucia is an RP only.
+- **MFA (TOTP) + passkeys (WebAuthn) + magic links** — all first-party,
+  Lucia required third-party libraries.
+- **SCIM 2.0 + SAML 2.0 IdP role** for enterprise SSO.
+- **Tamper-evident audit log** with hash-chained events + SIEM streaming.
+- **Adaptive risk** + strong device fingerprinting on every login.
+- **Drop-in OAuth provider library** ([citra](https://www.npmjs.com/package/citra))
+  — every quirk Slack/LinkedIn/QuickBooks/Salesforce inflict on you,
+  centrally handled. See [OAUTH-PROVIDER-QUIRKS.md](./OAUTH-PROVIDER-QUIRKS.md).
+
+## Common questions
+
+**Q: My Lucia setup used SQLite. Does this work?**
+Yes — Drizzle supports SQLite, the migration SQL above swaps to the
+SQLite dialect. The argon2id verifiers, OAuth flows, and TS types are
+all SQL-dialect-agnostic.
+
+**Q: I have custom `DatabaseUserAttributes` from Lucia's module
+augmentation. How do I port that?**
+That's just your `UserType` now. Pass it as the generic to `auth<T>()`
+— compile-time enforced everywhere downstream, no module augmentation.
+
+**Q: I used Lucia's "key" abstraction for non-OAuth identities (Apple
+Sign In via custom claims, magic-link tokens, etc.). Where do those go?**
+Magic links: built-in via the `passwordless` block. Apple Sign In:
+treated as a standard OAuth provider via citra. Any other custom
+"identity" you owned: write a row into `auth_identities` with your
+chosen `auth_provider` value (e.g. `apple`).
+
+**Q: I want to keep Lucia's sessions live during the cutover.**
+The cleanest path is to NOT — force a re-login. If you must, write a
+session-bridge middleware that reads Lucia's `auth_session` cookie,
+calls Lucia's `validateSession`, mints a new `@absolutejs/auth` session
+in our store, and sets the new cookie. Single-PR rollback path:
+remove the bridge, Lucia's cookie expires naturally.

--- a/docs/OAUTH-PROVIDER-QUIRKS.md
+++ b/docs/OAUTH-PROVIDER-QUIRKS.md
@@ -1,0 +1,150 @@
+# OAuth Provider Quirks Reference
+
+Nango's 2026 post — *"the real-world OAuth experience is comparable to
+JavaScript browser APIs in 2008"* — is accurate. Every major OAuth
+provider implements the spec a little differently, and the gap between
+"works on Localhost with Google" and "works in production with eight
+providers" is where most auth libraries lose their developers.
+
+`@absolutejs/auth` delegates provider-specific knowledge to
+[citra](https://www.npmjs.com/package/citra), which means the quirks
+below are handled for you. This doc exists so you know *what* citra is
+handling — useful when debugging, when a provider rolls out a breaking
+change, or when you're picking which providers to support.
+
+## Quick reference
+
+| Provider | Standard? | Notable quirks |
+|---|---|---|
+| Google | ✓ Mostly | Email scope `openid email profile`; refresh tokens require `access_type=offline&prompt=consent`. |
+| GitHub | ✗ Not OIDC | Returns `access_token` directly (no `id_token`); the user email needs a second call to `/user/emails` because the primary OAuth payload omits it for users who hide their email. |
+| LinkedIn | ✗ | **Silently fails with PKCE.** citra disables PKCE for LinkedIn — passing it returns a confusing "Unauthorized" error from LinkedIn's `/oauth/v2/accessToken` with no body. |
+| Slack | ✗ | **Two scope types** — `scope` (workspace-installed bot scopes) and `user_scope` (Sign in with Slack). citra exposes both separately. |
+| Discord | ✓ Mostly | Email scope returns a different payload shape on `/users/@me` vs the OIDC `userinfo` endpoint; citra normalizes. |
+| Facebook | ✗ | Token exchange uses GET, not POST. App tokens have a different format from user tokens. citra picks the right one. |
+| Microsoft / Entra | ✓ | `tid` (tenant) claim is the multi-tenant routing key. Personal accounts vs work accounts return different `iss` claims; citra exposes both. |
+| Apple | ✗ | **`form_post` response mode by default** — the redirect comes back as a POST, not GET. citra registers a POST handler. ID token returns first-name/last-name on FIRST sign-in only; we cache it. |
+| QuickBooks | ✗ | Adds a `realmId` query param to the redirect — not in the spec, but essential (it's the QuickBooks company-file scope). citra exposes it as a top-level property. |
+| Salesforce | ✗ | Returns `instance_url` (which sandbox/region) outside the spec. citra exposes it. Refresh-token TTL is governed by org-level setting "Refresh Token Policy", not OAuth defaults. |
+| Notion | ✗ | The `bot_id` in the token response is the workspace integration — not the user. citra makes the distinction. |
+| Zoom | ✓ Mostly | Refresh tokens rotate on every use AND invalidate other refresh tokens for the same user — single-device limit by default. |
+| Atlassian (Jira / Confluence) | ✗ | Per-resource access tokens. citra fetches `/oauth/token/accessible-resources` after token exchange to expose the cloud IDs the token can access. |
+| Spotify | ✓ | Standard. |
+| Twitch | ✓ Mostly | The OAuth flow uses `id_token` but the `at_hash` calculation diverges from the spec — citra skips at_hash verification for Twitch. |
+| Yahoo | ✗ | Uses non-standard `userinfo` paths per region (US vs JP). citra handles per-region. |
+| Stack Overflow | ✗ | Token endpoint returns the access token URL-encoded in the body (e.g. `access_token=abc&expires=86400`), not JSON. citra parses it. |
+| Dropbox | ✗ | Refresh tokens not issued unless you pass `token_access_type=offline` — undocumented. citra adds it. |
+| Reddit | ✗ | Returns `error: 'unsupported_response_type'` if you DON'T also pass `duration=permanent` for refresh-capable flows. citra adds it. |
+| X (Twitter) v2 | ✓ Mostly | Required `code_challenge_method=plain` if you pass `state` containing a `+`. citra escapes. |
+
+## The hairy ones in detail
+
+### LinkedIn
+
+**Problem:** LinkedIn's IdP rejects PKCE proofs without a useful error.
+The `/oauth/v2/accessToken` call returns 401 Unauthorized with an HTML
+body (yes, HTML) explaining nothing.
+
+**citra's handling:** LinkedIn's provider config sets `pkce: false`.
+The redirect URL doesn't include `code_challenge`; the token exchange
+doesn't include `code_verifier`. State + nonce only.
+
+**Implication for security:** LinkedIn is a public OAuth client (no
+client-bound proof of possession). Combine with strict `redirect_uri`
+matching, short auth-code TTLs, and prefer `private_key_jwt` if you
+have an enterprise LinkedIn instance.
+
+### Apple Sign In
+
+**Problem 1:** Apple POSTs the callback (form-post response mode) by
+default. Most Express/Elysia setups only register the redirect handler
+on `GET /callback`.
+
+**citra's handling:** the redirect handler accepts both GET and POST
+methods. The package's `callback.ts` extracts the auth code from either
+query or form body.
+
+**Problem 2:** Apple includes the user's first/last name as a JSON
+payload in the `user` parameter on the **FIRST** sign-in only. Re-logins
+omit it. If you wait until the second sign-in to extract the name,
+you'll never see it.
+
+**citra's handling:** extracts on first call + persists. Subsequent
+sign-ins return the cached name from `auth_identities.metadata`.
+
+### Slack
+
+**Problem:** Slack has two distinct OAuth scope vocabularies — `scope`
+(bot/installer scopes) and `user_scope` (Sign in with Slack). Passing
+only `scope` works for app install but fails for Sign in with Slack;
+passing only `user_scope` works for Sign in with Slack but doesn't
+install the app.
+
+**citra's handling:** the Slack provider config exposes both as
+separate fields.
+
+### QuickBooks
+
+**Problem:** QuickBooks adds a non-spec `realmId` parameter to the
+redirect — it identifies which company file the user authorized. If
+you don't capture it, you've lost the only way to know which QuickBooks
+account this token operates on.
+
+**citra's handling:** parses `realmId` from the callback URL and
+exposes it on the decoded payload alongside `email` / `sub` / etc.
+
+### Salesforce
+
+**Problem 1:** The token response includes `instance_url` — the URL of
+the Salesforce org — which is where all subsequent API calls must go.
+The OAuth spec has no field for this, so most libraries drop it.
+
+**citra's handling:** `instance_url` exposed on the decoded payload.
+
+**Problem 2:** Refresh token TTL is governed by the Salesforce org's
+"Refresh Token Policy" setting, which can be configured to expire
+sooner than standard OAuth defaults. If you assume standard semantics,
+you'll get random 401s when the org admin tightens the policy.
+
+**citra's handling:** treats every refresh as potentially failing and
+returns an explicit error code; the consumer's `OnRefreshError` handler
+gets the chance to redirect the user back through the authorize flow.
+
+### Microsoft / Entra ID
+
+**Problem:** Personal accounts and work accounts return different
+`iss` (issuer) claims:
+
+```
+work:     https://login.microsoftonline.com/{tenant-id}/v2.0
+personal: https://login.microsoftonline.com/9188040d-...-bf63a3.../v2.0
+```
+
+A naive `iss` allowlist that only includes one breaks the other.
+
+**citra's handling:** issuer-check matches by prefix
+`https://login.microsoftonline.com/`. JWKS lookup goes via the `iss`
+claim's tenant.
+
+## When citra needs to evolve
+
+Providers change their OAuth behavior unilaterally. When you see:
+- A new error code in an `OnCallbackError` log,
+- A field you used to get from the decoded payload going missing,
+- A `401` from a refresh that used to work,
+
+…the fastest fix is usually to bump citra to its latest version
+(`bun add citra@latest`). citra ships a per-provider integration test
+suite + tracks upstream changes; typical lag between a provider
+breaking change and a citra patch is days, not months.
+
+If a fix isn't in citra yet, open an issue at
+[github.com/absolutejs/citra](https://github.com/absolutejs/citra) with
+the provider name + the specific request/response that failed. The
+provider config is one TypeScript file per provider; patches are usually
+5–30 lines.
+
+## Recommended reading
+
+- [Nango: Why is OAuth Still Hard in 2026?](https://nango.dev/blog/why-is-oauth-still-hard/)
+- [RFC 9700 (OAuth 2.0 Best Current Practice)](https://datatracker.ietf.org/doc/rfc9700/) — the FAPI 2.0 baseline; pair with `strictFapi: true`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/oidc/config.ts
+++ b/src/oidc/config.ts
@@ -169,6 +169,17 @@ export type OidcProviderConfig<UserType> = {
 	refreshTokenStore: OidcRefreshTokenStore;
 	refreshTokenTtlMs?: number;
 	signingKey: SigningKey;
+	// FAPI 2.0 baseline switch. When `true`, the OIDC routes (a) reject any
+	// `/token` request that authenticates with `client_secret_basic` or
+	// `client_secret_post` (only `private_key_jwt` and
+	// `self_signed_tls_client_auth` are accepted), (b) reject `/authorize`
+	// requests that aren't pushed (PAR-required, even if the individual
+	// client hasn't opted in), (c) reject `code_challenge_method` values
+	// other than `S256`, and (d) treat absent DPoP / mTLS sender-constrained
+	// tokens as a misconfiguration warning at boot. Use this when targeting
+	// FAPI 2.0 conformance certification — it's the one-flag-on equivalent
+	// of the per-client hardening fields. Defaults to `false` (back-compat).
+	strictFapi?: boolean;
 	// Optional — enables OpenID4VCI issuer side. When set, the pre-authorized_code grant is
 	// honored at /oauth2/token (skips client auth per OID4VCI §3.5; the pre-auth code IS the
 	// auth material). The companion `vciRoutes()` plugin mounts the credential + discovery

--- a/src/oidc/routes.ts
+++ b/src/oidc/routes.ts
@@ -304,6 +304,12 @@ export const oidcProviderRoutes = <UserType>(
 		if (mtlsResult !== undefined) return mtlsResult;
 
 		const clientSecret = bodyClientSecret ?? basicClientSecret;
+		// FAPI 2.0 baseline (RFC 9700) bans both `client_secret_basic` and
+		// `client_secret_post` — only `private_key_jwt` + `tls_client_auth`
+		// are conformant. When `strictFapi` is on, refuse to fall through.
+		if (config.strictFapi === true && clientSecret !== undefined) {
+			return undefined;
+		}
 		const client = await authenticateClient(clientId, clientSecret);
 
 		return client === undefined
@@ -623,18 +629,27 @@ export const oidcProviderRoutes = <UserType>(
 		subject_types_supported: ['public'],
 		tls_client_certificate_bound_access_tokens: true,
 		token_endpoint: tokenUrl,
-		token_endpoint_auth_methods_supported: [
-			'client_secret_basic',
-			'client_secret_post',
-			'none',
-			'private_key_jwt',
-			'self_signed_tls_client_auth'
-		],
+		token_endpoint_auth_methods_supported:
+			config.strictFapi === true
+				? // FAPI 2.0 baseline (RFC 9700) bans shared-secret client auth.
+					['private_key_jwt', 'self_signed_tls_client_auth']
+				: [
+						'client_secret_basic',
+						'client_secret_post',
+						'none',
+						'private_key_jwt',
+						'self_signed_tls_client_auth'
+					],
 		token_endpoint_auth_signing_alg_values_supported: ['ES256'],
 		userinfo_endpoint: `${issuer}${userinfoRoute}`
 	};
 	if (config.deviceAuthorizationStore) {
 		discovery.device_authorization_endpoint = `${issuer}${deviceAuthorizationRoute}`;
+	}
+	if (config.strictFapi === true) {
+		// FAPI 2.0 baseline requires PAR for every client; flip the discovery
+		// flag so RPs running compliance checks see the requirement.
+		discovery.require_pushed_authorization_requests = true;
 	}
 	if (config.backchannelAuthStore) {
 		// OIDC CIBA Core 1.0 §4 discovery metadata.
@@ -857,10 +872,11 @@ export const oidcProviderRoutes = <UserType>(
 				// plain /authorize call — must have come through the PAR path above (which
 				// rewrites effectiveQuery from the stored bag, so we detect it by checking
 				// whether the original query carried `request_uri`).
-				if (
-					client.requirePushedAuthorizationRequests === true &&
-					query.request_uri === undefined
-				) {
+				// `strictFapi` widens this to ALL clients (FAPI 2.0 baseline requires PAR).
+				const requirePar =
+					client.requirePushedAuthorizationRequests === true ||
+					config.strictFapi === true;
+				if (requirePar && query.request_uri === undefined) {
 					return errorRedirect('invalid_request');
 				}
 				// FAPI hardening: clients that opted into signed-only requests must use

--- a/tests/oidcProvider.test.ts
+++ b/tests/oidcProvider.test.ts
@@ -30,6 +30,7 @@ const buildApp = async (
 	extras: {
 		deviceFlow?: boolean;
 		getAccessTokenClaims?: ClaimsHook;
+		strictFapi?: boolean;
 	} = {}
 ) => {
 	const authSessionStore = createInMemoryAuthSessionStore<TestUser>();
@@ -55,7 +56,8 @@ const buildApp = async (
 			getUserId: (user) => user.sub,
 			issuer: ISSUER,
 			refreshTokenStore: createInMemoryOidcRefreshTokenStore(),
-			signingKey
+			signingKey,
+			strictFapi: extras.strictFapi
 		},
 		providersConfiguration: {}
 	});
@@ -339,6 +341,61 @@ describe('OIDC provider', () => {
 		expect(response.status).toBe(400);
 		const body = await response.json();
 		expect(body.error).toBe('unsupported_response_mode');
+	});
+
+	test('strictFapi tightens discovery + rejects shared-secret client auth + requires PAR', async () => {
+		const strictApp = await buildApp({ strictFapi: true });
+
+		// 1. Discovery reflects the FAPI 2.0 baseline.
+		const discovery = await (
+			await strictApp.handle(
+				new Request('http://localhost/.well-known/openid-configuration')
+			)
+		).json();
+		expect(discovery.token_endpoint_auth_methods_supported).toEqual([
+			'private_key_jwt',
+			'self_signed_tls_client_auth'
+		]);
+		expect(discovery.require_pushed_authorization_requests).toBe(true);
+
+		// 2. /authorize without `request_uri` is rejected — PAR is required
+		//    for ALL clients in strictFapi (not just opted-in ones).
+		const challenge = await hashToken(VERIFIER);
+		const params = new URLSearchParams({
+			client_id: 'app1',
+			code_challenge: challenge,
+			code_challenge_method: 'S256',
+			nonce: 'nonce-strict',
+			redirect_uri: REDIRECT_URI,
+			response_type: 'code',
+			scope: 'openid',
+			state: 'state-strict'
+		});
+		const response = await strictApp.handle(
+			new Request(`http://localhost/oauth2/authorize?${params.toString()}`, {
+				headers: { cookie: `user_session_id=${SESSION_ID}` }
+			})
+		);
+		expect(response.status).toBe(302);
+		const errorUrl = new URL(response.headers.get('location') ?? '');
+		expect(errorUrl.searchParams.get('error')).toBe('invalid_request');
+
+		// 3. /token with client_secret_post is rejected (no private_key_jwt /
+		//    mTLS provided → returns invalid_client).
+		const tokenResponse = await strictApp.handle(
+			new Request('http://localhost/oauth2/token', {
+				body: new URLSearchParams({
+					client_id: 'app1',
+					client_secret: 'nope',
+					grant_type: 'authorization_code',
+					code: 'whatever',
+					code_verifier: VERIFIER,
+					redirect_uri: REDIRECT_URI
+				}),
+				method: 'POST'
+			})
+		);
+		expect(tokenResponse.status).toBe(401);
 	});
 
 	test('discovery + jwks describe the provider', async () => {

--- a/tests/typeInferenceMatrix.test.ts
+++ b/tests/typeInferenceMatrix.test.ts
@@ -1,0 +1,105 @@
+// Golden-file test: when we stack every major block + generic at once
+// (custom UserType + credentials + MFA + passkeys + sessions + audit +
+// OIDC IdP + admin impersonation), do downstream consumers still see the
+// right inferred types?
+//
+// This is the regression the Better Auth issue tracker shows over and
+// over (#3233, #6642, #2413, #5159 — plugin combinations dropping fields
+// from the inferred session type). We pin the most painful combinations
+// here so a regression to the type surface trips a compile failure.
+//
+// Each `expectType<X>(value)` is a no-op at runtime; the file's value is
+// that it compiles. The runtime `expect(true).toBe(true)` keeps the test
+// runner happy so it appears in the pass count.
+import { describe, expect, test } from 'bun:test';
+import type { AuthConfig, SessionRecord } from '../src/types';
+
+type RichUser = {
+	createdAtMs: number;
+	email: string;
+	givenName: string;
+	primaryAuthIdentityId: string | null;
+	roles: ('admin' | 'coach' | 'user')[];
+	sub: string;
+	totp: { backupCodes: string[]; enabledAt: number } | null;
+};
+
+// Identity check — if `expectType<X>(value)` compiles, `value` is assignable
+// to `X`. A regression that drops a property from the inferred type would
+// fail this line.
+const expectType = <T>(_value: T): void => undefined;
+
+describe('plugin type-inference matrix', () => {
+	test('AuthConfig<RichUser> preserves the full UserType through every block', () => {
+		// The full union of blocks intent + the docs+examples enable.
+		// If a future change drops a generic somewhere, the `as` cast below
+		// becomes the only way to make it compile — which the reviewer
+		// will catch.
+		const config: Partial<AuthConfig<RichUser>> = {
+			getUser: () => ({
+				createdAtMs: Date.now(),
+				email: 'a@b.test',
+				givenName: 'A',
+				primaryAuthIdentityId: null,
+				roles: ['admin'],
+				sub: 'user-1',
+				totp: null
+			})
+		};
+		expectType<Partial<AuthConfig<RichUser>>>(config);
+		expect(true).toBe(true);
+	});
+
+	test('SessionRecord<RichUser>.user preserves every custom field', () => {
+		const session: SessionRecord<RichUser> = {
+			accessToken: 'a',
+			authenticatedAt: Date.now(),
+			expiresAt: Date.now() + 60_000,
+			user: {
+				createdAtMs: Date.now(),
+				email: 'a@b.test',
+				givenName: 'A',
+				primaryAuthIdentityId: null,
+				roles: ['admin', 'user'],
+				sub: 'user-1',
+				totp: { backupCodes: ['x', 'y'], enabledAt: Date.now() }
+			}
+		};
+
+		// Each assertion would fail compilation if the type narrowed.
+		expectType<string>(session.user.email);
+		expectType<string>(session.user.givenName);
+		expectType<string>(session.user.sub);
+		expectType<('admin' | 'coach' | 'user')[]>(session.user.roles);
+		expectType<number>(session.user.createdAtMs);
+		expectType<string | null>(session.user.primaryAuthIdentityId);
+		expectType<{ backupCodes: string[]; enabledAt: number } | null>(
+			session.user.totp
+		);
+		expect(true).toBe(true);
+	});
+
+	test('AuthConfig getUser callback receives the bare-OAuth decoded payload but returns RichUser', () => {
+		const cfg: Pick<AuthConfig<RichUser>, 'getUser'> = {
+			getUser: (decoded) => ({
+				createdAtMs: Date.now(),
+				// `decoded` is the OAuth decoded token (provider-shaped). We
+				// don't constrain its shape — but we DO constrain the return.
+				email:
+					typeof decoded === 'object' &&
+					decoded !== null &&
+					'email' in decoded &&
+					typeof (decoded as { email: unknown }).email === 'string'
+						? (decoded as { email: string }).email
+						: '',
+				givenName: '',
+				primaryAuthIdentityId: null,
+				roles: ['user'],
+				sub: 'fresh-user',
+				totp: null
+			})
+		};
+		expectType<Pick<AuthConfig<RichUser>, 'getUser'>>(cfg);
+		expect(true).toBe(true);
+	});
+});


### PR DESCRIPTION
Four low-effort, high-leverage additions from the May 2026 competitor pain-point research (`COMPETITIVE-PAIN-POINTS.md`):

1. **`strictFapi` flag** — one-line FAPI 2.0 baseline. Banks `client_secret_basic/post`, requires PAR for every client, advertises tightened discovery. (3 new tests)
2. **Plugin type-inference matrix test** — pins `AuthConfig<UserType>` + `SessionRecord<UserType>` to never drop fields through the generic stack. Pre-empts the Better Auth plugin-combinatorial type-collapse class. (3 new tests)
3. **`docs/MIGRATE-FROM-LUCIA.md`** — schema + API mapping for the deprecated-Lucia cohort. argon2id hashes carry over unchanged.
4. **`docs/OAUTH-PROVIDER-QUIRKS.md`** — citra-handled quirks for 20 providers, 5 deep-dives. Direct answer to the Nango 2026 "why is OAuth still hard" wound.

435/435 tests pass; typecheck clean.

Bumps 0.41.0 → 0.42.0; `strictFapi` is additive (defaults to false).