### PR TITLE
feat: drop-in headless React components + Vue/Svelte/Solid recipes (0.44.0)

### DIFF
--- a/docs/UI-COMPONENTS.md
+++ b/docs/UI-COMPONENTS.md
@@ -1,0 +1,226 @@
+# Drop-in UI Components
+
+The most common reason developers stay on Clerk / Auth0 isn't the auth
+itself — it's the polished `<UserButton />` and `<SignIn />` components
+that go with them. This page is the answer to *"but I'd lose Clerk's
+`<UserButton />`."*
+
+`@absolutejs/auth` ships three headless components (React) + the recipe
+to build the same in Vue / Svelte / Solid using the existing
+composables. Every component is restyleable via a `classNames` prop;
+every internal element carries a `data-abs-auth="…"` attribute the
+consumer can target from CSS without touching the source.
+
+## React
+
+The components are real React functional components in
+`@absolutejs/auth/react`:
+
+```tsx
+import { authClient } from './shared/authClient'; // your createAuthClient instance
+import { SignIn, SignUp, UserButton } from '@absolutejs/auth/react';
+
+// Sign-in page
+<SignIn
+  client={authClient}
+  providers={['google', 'github']}  // optional OAuth buttons above the form
+  onSuccess={(result) => {
+    if (result.status === 'mfa_required') router.push('/mfa');
+    else router.push('/dashboard');
+  }}
+  onError={(error) => console.error(error.message)}
+  classNames={{
+    container: 'flex flex-col gap-4 max-w-sm',
+    button: 'rounded-md bg-violet-600 text-white py-2',
+    input: 'border-slate-200 border rounded px-3 py-2',
+    // …all classNames are optional
+  }}
+/>
+
+// Sign-up page (always email/password; OAuth registration uses /authorize directly)
+<SignUp
+  client={authClient}
+  onSuccess={(result) => {
+    if (result.status === 'verification_required') router.push('/verify-email');
+    else router.push('/dashboard');
+  }}
+/>
+
+// Top navigation user button
+<UserButton
+  client={authClient}
+  user={user}  // your AuthUser-shaped record (you keep the session state)
+  items={[
+    { label: 'Settings', href: '/settings' },
+    { label: 'API keys', href: '/settings/api' },
+  ]}
+  onSignOut={() => router.push('/')}
+/>
+```
+
+### `data-abs-auth` attributes — restyle without classNames
+
+If you don't want to thread classNames through every render call, set
+your CSS based on the data attribute selector:
+
+```css
+[data-abs-auth='sign-in'] { display: flex; flex-direction: column; gap: 1rem; }
+[data-abs-auth='submit']:disabled { opacity: 0.5; cursor: not-allowed; }
+[data-abs-auth='oauth-grid'] { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; }
+[data-abs-auth='menu'] { position: absolute; right: 0; top: 100%; }
+```
+
+## Vue 3 — copy-paste recipes
+
+Vue SFCs have their own compile step that's outside this package's
+build scope, so we ship the composables (`useSignIn`, `useSignUp`,
+`useSignOut`) and you drop a ~30-line SFC into your project:
+
+```vue
+<!-- src/components/auth/SignIn.vue -->
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useSignIn } from '@absolutejs/auth/vue';
+import type { AuthClient } from '@absolutejs/auth/client';
+
+const props = defineProps<{ client: AuthClient }>();
+const emit = defineEmits<{ success: [unknown]; error: [Error] }>();
+
+const email = ref('');
+const password = ref('');
+const { error, isPending, mutate } = useSignIn(props.client);
+
+const onSubmit = async () => {
+  const result = await mutate({ email: email.value, password: password.value });
+  if (result.error !== null) emit('error', result.error);
+  else if (result.data !== null) emit('success', result.data);
+};
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit" data-abs-auth="sign-in">
+    <label data-abs-auth="email-field">
+      <span>Email</span>
+      <input v-model="email" type="email" autocomplete="username webauthn" required />
+    </label>
+    <label data-abs-auth="password-field">
+      <span>Password</span>
+      <input v-model="password" type="password" autocomplete="current-password" minlength="12" required />
+    </label>
+    <p v-if="$error" role="alert" data-abs-auth="error">{{ $error.message }}</p>
+    <button type="submit" :disabled="isPending" data-abs-auth="submit">
+      {{ isPending ? 'Signing in…' : 'Sign in' }}
+    </button>
+  </form>
+</template>
+```
+
+`SignUp.vue` and `UserButton.vue` follow the same shape — swap
+`useSignIn` for `useSignUp` / `useSignOut`.
+
+## Svelte 5 (runes) — copy-paste recipe
+
+```svelte
+<!-- src/lib/components/SignIn.svelte -->
+<script lang="ts">
+  import { useSignIn } from '@absolutejs/auth/svelte';
+  import type { AuthClient } from '@absolutejs/auth/client';
+
+  let { client, onSuccess, onError }: {
+    client: AuthClient;
+    onSuccess?: (result: unknown) => void;
+    onError?: (error: Error) => void;
+  } = $props();
+
+  let email = $state('');
+  let password = $state('');
+  const { error, isPending, mutate } = useSignIn(client);
+
+  const onSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+    const result = await mutate({ email, password });
+    if (result.error !== null) onError?.(result.error);
+    else if (result.data !== null) onSuccess?.(result.data);
+  };
+</script>
+
+<form onsubmit={onSubmit} data-abs-auth="sign-in">
+  <label data-abs-auth="email-field">
+    <span>Email</span>
+    <input bind:value={email} type="email" autocomplete="username webauthn" required />
+  </label>
+  <label data-abs-auth="password-field">
+    <span>Password</span>
+    <input bind:value={password} type="password" autocomplete="current-password" minlength="12" required />
+  </label>
+  {#if $error}
+    <p role="alert" data-abs-auth="error">{$error.message}</p>
+  {/if}
+  <button type="submit" disabled={$isPending} data-abs-auth="submit">
+    {$isPending ? 'Signing in…' : 'Sign in'}
+  </button>
+</form>
+```
+
+## Solid — copy-paste recipe
+
+```tsx
+// src/components/auth/SignIn.tsx
+import { createSignal, type Component } from 'solid-js';
+import { useSignIn } from '@absolutejs/auth/solid';
+import type { AuthClient } from '@absolutejs/auth/client';
+
+export const SignIn: Component<{
+  client: AuthClient;
+  onSuccess?: (result: unknown) => void;
+  onError?: (error: Error) => void;
+}> = (props) => {
+  const [email, setEmail] = createSignal('');
+  const [password, setPassword] = createSignal('');
+  const { error, isPending, mutate } = useSignIn(props.client);
+
+  const onSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+    const result = await mutate({ email: email(), password: password() });
+    if (result.error !== null) props.onError?.(result.error);
+    else if (result.data !== null) props.onSuccess?.(result.data);
+  };
+
+  return (
+    <form onSubmit={onSubmit} data-abs-auth="sign-in">
+      <label data-abs-auth="email-field">
+        <span>Email</span>
+        <input value={email()} onInput={(e) => setEmail(e.currentTarget.value)}
+               type="email" autocomplete="username webauthn" required />
+      </label>
+      <label data-abs-auth="password-field">
+        <span>Password</span>
+        <input value={password()} onInput={(e) => setPassword(e.currentTarget.value)}
+               type="password" autocomplete="current-password" minlength={12} required />
+      </label>
+      {error() && (
+        <p role="alert" data-abs-auth="error">{error()!.message}</p>
+      )}
+      <button type="submit" disabled={isPending()} data-abs-auth="submit">
+        {isPending() ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  );
+};
+```
+
+## Why we don't ship Vue/Svelte/Solid SFCs in the package
+
+Each non-React framework needs its own SFC compiler bundled into the
+build pipeline (`@vitejs/plugin-vue`, `@sveltejs/vite-plugin-svelte`,
+`solid-vite`). Adopting four parallel build paths in a single package
+inflates the install footprint by 30–60 MB and creates a maintenance
+matrix that the React-only approach doesn't have.
+
+The composables (`useSignIn`, `useSignUp`, etc.) are framework-native
+and shipped in `@absolutejs/auth/{vue,svelte,solid}`. Wiring a
+20-30-line SFC over them is faster than configuring our build to ship
+them precompiled — and gives you full control of the markup.
+
+If you'd like SFC-native components added to the package despite the
+build cost, open an issue.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.43.0",
+	"version": "0.44.0",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/client/components/react/SignIn.ts
+++ b/src/client/components/react/SignIn.ts
@@ -1,0 +1,183 @@
+// Drop-in sign-in component for React. Headless — minimal default
+// markup, every element has a stable `data-abs-auth` attribute the
+// consumer can target from their own CSS. Doesn't bundle styles;
+// consumers bring their own (Tailwind class lists, CSS-in-JS,
+// vanilla CSS, whatever).
+//
+// Usage:
+//
+//   import { SignIn } from '@absolutejs/auth/react';
+//
+//   <SignIn
+//     client={authClient}
+//     onSuccess={() => router.push('/dashboard')}
+//     providers={['google', 'github']}
+//   />
+//
+// The component renders an email/password form, calls the package's
+// useSignIn hook on submit, and emits onSuccess/onError. OAuth provider
+// buttons (when `providers` is set) are real anchor links to
+// `/oauth2/authorize?provider=…` — the consumer's existing OAuth
+// roundtrip + onCallbackSuccess hook is what handles the rest.
+import { createElement, type FormEvent } from 'react';
+import { useState } from 'react';
+import type { AuthClient, AuthClientError } from '../../createAuthClient';
+import { useSignIn } from '../../react';
+
+type AuthnSuccess = {
+	passwordCompromised?: boolean;
+	status: 'authenticated' | 'mfa_required';
+};
+
+export type SignInProps = {
+	client: AuthClient;
+	classNames?: {
+		button?: string;
+		container?: string;
+		divider?: string;
+		error?: string;
+		field?: string;
+		input?: string;
+		label?: string;
+		oauthButton?: string;
+		oauthGrid?: string;
+	};
+	emailLabel?: string;
+	onError?: (error: AuthClientError) => void;
+	onSuccess?: (result: AuthnSuccess) => void;
+	passwordLabel?: string;
+	// OAuth provider keys (lowercase, matching your auth() config) to render
+	// as buttons above the email/password form. e.g. ['google', 'github'].
+	providers?: string[];
+	submitLabel?: string;
+};
+
+export const SignIn = ({
+	client,
+	classNames,
+	emailLabel = 'Email',
+	onError,
+	onSuccess,
+	passwordLabel = 'Password',
+	providers,
+	submitLabel = 'Sign in'
+}: SignInProps) => {
+	const [email, setEmail] = useState('');
+	const [password, setPassword] = useState('');
+	const { error, isPending, mutate } = useSignIn(client);
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const result = await mutate({ email, password });
+		if (result.error !== null) {
+			onError?.(result.error);
+
+			return;
+		}
+		if (result.data !== null) onSuccess?.(result.data);
+	};
+
+	const oauthButtons =
+		providers === undefined || providers.length === 0
+			? null
+			: createElement(
+					'div',
+					{
+						className: classNames?.oauthGrid,
+						'data-abs-auth': 'oauth-grid'
+					},
+					...providers.map((provider) =>
+						createElement(
+							'a',
+							{
+								className: classNames?.oauthButton,
+								'data-abs-auth-provider': provider,
+								href: `/oauth2/authorize?provider=${provider}`,
+								key: provider
+							},
+							`Continue with ${provider}`
+						)
+					),
+					createElement(
+						'div',
+						{
+							className: classNames?.divider,
+							'data-abs-auth': 'divider'
+						},
+						'or'
+					)
+				);
+
+	const errorBanner =
+		error === null
+			? null
+			: createElement(
+					'p',
+					{
+						className: classNames?.error,
+						'data-abs-auth': 'error',
+						role: 'alert'
+					},
+					error.message
+				);
+
+	return createElement(
+		'form',
+		{
+			className: classNames?.container,
+			'data-abs-auth': 'sign-in',
+			onSubmit: handleSubmit
+		},
+		oauthButtons,
+		createElement(
+			'label',
+			{ className: classNames?.field, 'data-abs-auth': 'email-field' },
+			createElement(
+				'span',
+				{ className: classNames?.label },
+				emailLabel
+			),
+			createElement('input', {
+				autoComplete: 'username webauthn',
+				className: classNames?.input,
+				name: 'email',
+				onChange: (event: { currentTarget: HTMLInputElement }) =>
+					setEmail(event.currentTarget.value),
+				required: true,
+				type: 'email',
+				value: email
+			})
+		),
+		createElement(
+			'label',
+			{ className: classNames?.field, 'data-abs-auth': 'password-field' },
+			createElement(
+				'span',
+				{ className: classNames?.label },
+				passwordLabel
+			),
+			createElement('input', {
+				autoComplete: 'current-password',
+				className: classNames?.input,
+				minLength: 12,
+				name: 'password',
+				onChange: (event: { currentTarget: HTMLInputElement }) =>
+					setPassword(event.currentTarget.value),
+				required: true,
+				type: 'password',
+				value: password
+			})
+		),
+		errorBanner,
+		createElement(
+			'button',
+			{
+				className: classNames?.button,
+				'data-abs-auth': 'submit',
+				disabled: isPending,
+				type: 'submit'
+			},
+			isPending ? 'Signing in…' : submitLabel
+		)
+	);
+};

--- a/src/client/components/react/SignUp.ts
+++ b/src/client/components/react/SignUp.ts
@@ -1,0 +1,126 @@
+// Drop-in sign-up component for React. Mirrors SignIn but calls
+// useSignUp + advertises the 12-character minimum-length we enforce
+// at the package level. See SignIn for the design rationale + the
+// data-abs-auth attribute hook system.
+import { createElement, type FormEvent } from 'react';
+import { useState } from 'react';
+import type { AuthClient, AuthClientError } from '../../createAuthClient';
+import { useSignUp } from '../../react';
+
+type SignUpSuccess =
+	| { status: 'authenticated' }
+	| { status: 'verification_required' };
+
+export type SignUpProps = {
+	client: AuthClient;
+	classNames?: {
+		button?: string;
+		container?: string;
+		error?: string;
+		field?: string;
+		input?: string;
+		label?: string;
+	};
+	emailLabel?: string;
+	onError?: (error: AuthClientError) => void;
+	onSuccess?: (result: SignUpSuccess) => void;
+	passwordLabel?: string;
+	submitLabel?: string;
+};
+
+export const SignUp = ({
+	client,
+	classNames,
+	emailLabel = 'Email',
+	onError,
+	onSuccess,
+	passwordLabel = 'Password (12+ characters)',
+	submitLabel = 'Create account'
+}: SignUpProps) => {
+	const [email, setEmail] = useState('');
+	const [password, setPassword] = useState('');
+	const { error, isPending, mutate } = useSignUp(client);
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const result = await mutate({ email, password });
+		if (result.error !== null) {
+			onError?.(result.error);
+
+			return;
+		}
+		if (result.data !== null) onSuccess?.(result.data);
+	};
+
+	const errorBanner =
+		error === null
+			? null
+			: createElement(
+					'p',
+					{
+						className: classNames?.error,
+						'data-abs-auth': 'error',
+						role: 'alert'
+					},
+					error.message
+				);
+
+	return createElement(
+		'form',
+		{
+			className: classNames?.container,
+			'data-abs-auth': 'sign-up',
+			onSubmit: handleSubmit
+		},
+		createElement(
+			'label',
+			{ className: classNames?.field, 'data-abs-auth': 'email-field' },
+			createElement(
+				'span',
+				{ className: classNames?.label },
+				emailLabel
+			),
+			createElement('input', {
+				autoComplete: 'email',
+				className: classNames?.input,
+				name: 'email',
+				onChange: (event: { currentTarget: HTMLInputElement }) =>
+					setEmail(event.currentTarget.value),
+				required: true,
+				type: 'email',
+				value: email
+			})
+		),
+		createElement(
+			'label',
+			{ className: classNames?.field, 'data-abs-auth': 'password-field' },
+			createElement(
+				'span',
+				{ className: classNames?.label },
+				passwordLabel
+			),
+			createElement('input', {
+				autoComplete: 'new-password',
+				className: classNames?.input,
+				minLength: 12,
+				name: 'password',
+				onChange: (event: { currentTarget: HTMLInputElement }) =>
+					setPassword(event.currentTarget.value),
+				required: true,
+				type: 'password',
+				value: password
+			})
+		),
+		errorBanner,
+		createElement(
+			'button',
+			{
+				className: classNames?.button,
+				'data-abs-auth': 'submit',
+				disabled: isPending,
+				type: 'submit'
+			},
+			isPending ? 'Creating account…' : submitLabel
+		)
+	);
+};

--- a/src/client/components/react/UserButton.ts
+++ b/src/client/components/react/UserButton.ts
@@ -1,0 +1,163 @@
+// Drop-in current-user button for React. The component that Clerk's
+// `<UserButton />` was sticky for: shows the signed-in user's email +
+// avatar, expands to a menu on click, exposes sign-out + a
+// customizable list of links.
+//
+// Usage:
+//
+//   <UserButton
+//     client={authClient}
+//     user={user}            // your AuthUser-shaped record
+//     items={[
+//       { label: 'Settings', href: '/settings' },
+//       { label: 'API keys', href: '/settings/api' }
+//     ]}
+//     onSignOut={() => router.push('/')}
+//   />
+//
+// The component owns NO data fetching — the consumer passes `user` from
+// wherever they keep session state. Sign-out goes through the package's
+// /oauth2/signout (universal across credential + OAuth sessions since
+// 0.32.0).
+import { createElement, useState } from 'react';
+import type { AuthClient } from '../../createAuthClient';
+import { useSignOut } from '../../react';
+
+export type UserButtonUser = {
+	avatarUrl?: string;
+	email?: string;
+	givenName?: string;
+};
+
+export type UserButtonItem = {
+	href: string;
+	label: string;
+};
+
+export type UserButtonProps = {
+	client: AuthClient;
+	classNames?: {
+		avatar?: string;
+		container?: string;
+		email?: string;
+		menu?: string;
+		menuItem?: string;
+		signOut?: string;
+		toggle?: string;
+	};
+	items?: UserButtonItem[];
+	onSignOut?: () => void;
+	signedOutHref?: string;
+	signOutLabel?: string;
+	user: UserButtonUser | null;
+};
+
+const initial = (user: UserButtonUser) => {
+	const source = user.givenName ?? user.email ?? '?';
+
+	return source.slice(0, 1).toUpperCase();
+};
+
+export const UserButton = ({
+	client,
+	classNames,
+	items,
+	onSignOut,
+	signedOutHref = '/',
+	signOutLabel = 'Sign out',
+	user
+}: UserButtonProps) => {
+	const [open, setOpen] = useState(false);
+	const { mutate } = useSignOut(client);
+
+	if (user === null) {
+		return createElement(
+			'a',
+			{
+				className: classNames?.toggle,
+				'data-abs-auth': 'signed-out',
+				href: signedOutHref
+			},
+			'Sign in'
+		);
+	}
+
+	const menu = open
+		? createElement(
+				'div',
+				{
+					className: classNames?.menu,
+					'data-abs-auth': 'menu'
+				},
+				...((items ?? []).map((item) =>
+					createElement(
+						'a',
+						{
+							className: classNames?.menuItem,
+							'data-abs-auth-menu-item': item.label,
+							href: item.href,
+							key: item.href
+						},
+						item.label
+					)
+				) as ReturnType<typeof createElement>[]),
+				createElement(
+					'button',
+					{
+						className: classNames?.signOut,
+						'data-abs-auth': 'sign-out',
+						onClick: async () => {
+							await mutate(undefined);
+							setOpen(false);
+							onSignOut?.();
+						},
+						type: 'button'
+					},
+					signOutLabel
+				)
+			)
+		: null;
+
+	const avatar =
+		user.avatarUrl === undefined
+			? createElement(
+					'span',
+					{
+						className: classNames?.avatar,
+						'data-abs-auth': 'avatar-initial'
+					},
+					initial(user)
+				)
+			: createElement('img', {
+					alt: '',
+					className: classNames?.avatar,
+					'data-abs-auth': 'avatar',
+					src: user.avatarUrl
+				});
+
+	return createElement(
+		'div',
+		{
+			className: classNames?.container,
+			'data-abs-auth': 'user-button',
+			'data-abs-auth-open': open ? 'true' : 'false'
+		},
+		createElement(
+			'button',
+			{
+				'aria-expanded': open,
+				className: classNames?.toggle,
+				'data-abs-auth': 'user-toggle',
+				onClick: () => setOpen((prev) => !prev),
+				type: 'button'
+			},
+			avatar,
+			createElement(
+				'span',
+				{ className: classNames?.email, 'data-abs-auth': 'user-email' },
+				user.givenName ?? user.email ?? 'Account'
+			)
+		),
+		menu
+	);
+};

--- a/src/client/react.ts
+++ b/src/client/react.ts
@@ -200,3 +200,18 @@ export const useSignOut = (client: AuthClient) => useMutation(client.signOut);
 
 export const useSignUp = (client: AuthClient) =>
 	useMutation(client.signUp.email);
+
+// Drop-in headless components — minimal default markup, fully
+// restyleable via the `classNames` prop. Every element carries a
+// `data-abs-auth=…` attribute the consumer can target from CSS. Useful
+// when migrating off Clerk's `<UserButton />` / `<SignIn />`: pass
+// `classNames` to match your existing visual treatment, drop the
+// vendor dep.
+export { SignIn, type SignInProps } from './components/react/SignIn';
+export { SignUp, type SignUpProps } from './components/react/SignUp';
+export {
+	UserButton,
+	type UserButtonItem,
+	type UserButtonProps,
+	type UserButtonUser
+} from './components/react/UserButton';


### PR DESCRIPTION
The #2 highest-leverage move from `COMPETITIVE-PAIN-POINTS.md`. Clerk's `<UserButton />`/`<SignIn />` are the genuine stickiness — this PR ships the minimum-viable answer.

## React

`@absolutejs/auth/react` gains three new exports:

- **`<SignIn />`** — email/password form + optional OAuth provider buttons. Uses `useSignIn` under the hood.
- **`<SignUp />`** — email/password registration. Uses `useSignUp`.
- **`<UserButton />`** — current-user button with expand-to-menu + custom items. Uses `useSignOut` + universal-signout (`/oauth2/signout`, since 0.32.0).

All three are **headless**: minimal default markup, every internal element carries a stable `data-abs-auth="…"` attribute. Restyle via the `classNames` prop OR via CSS data attribute selectors — either works.

No JSX needed (uses `React.createElement`), so no build config changes.

## docs/UI-COMPONENTS.md

Documents the React API + ships ~30-line copy-paste recipes for the same three components in Vue 3 SFC, Svelte 5 (runes), and Solid. Each wires to the existing per-framework composables.

Explains why we don't precompile SFCs into the package (build-pipeline cost) — opens the door to ship them if someone files an issue.

## Bump

0.43.0 → 0.44.0. Additive. 441/441 tests pass; typecheck clean.