### PR TITLE
docs: rebrand conformance reference to auth.absolutejs.com

### DIFF
--- a/OPENID-CONFORMANCE-CERTIFICATION.md
+++ b/OPENID-CONFORMANCE-CERTIFICATION.md
@@ -51,7 +51,7 @@ Before paying anyone:
 1. **Set up a public reference instance.** The conformance suite needs a live OP at a real URL it can hit. Could be:
    - An always-on instance running on DigitalOcean / Fly / Render with the package's `@absolutejs/auth` configured
    - Reuse the intent prod URL (intentshowcases.com) — risky because the conformance suite tries weird inputs
-   - **Recommendation:** dedicated `oidc-conformance.absolutejs.com` instance running a minimal `defineAuthConfig` with every block enabled, isolated from intent
+   - **Recommendation:** dedicated `auth.absolutejs.com` instance running a minimal `defineAuthConfig` with every block enabled, isolated from intent
 
 2. **Run the self-test suite locally.** The OpenID conformance test suite is open source at <https://gitlab.com/openid/conformance-suite>. Self-hostable via Docker. Free to run; finding gaps now (before paying for certification) is the whole point of the self-test phase.
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -17,7 +17,7 @@ on-demand into a sibling directory.
 ./conformance/setup.sh
 
 # 2. point at any URL that serves a `@absolutejs/auth` discovery document
-TARGET_ISSUER=https://oidc-conformance.absolutejs.com ./conformance/run.sh
+TARGET_ISSUER=https://auth.absolutejs.com ./conformance/run.sh
 
 # 3. browse results: http://localhost:8443/
 #    Default credentials: ssl/ca, see suite docs

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -16,7 +16,7 @@ TARGET_ISSUER="${TARGET_ISSUER:-}"
 
 if [ -z "$TARGET_ISSUER" ]; then
 	echo "[run] error: set TARGET_ISSUER, e.g.:" >&2
-	echo "      TARGET_ISSUER=https://oidc-conformance.absolutejs.com ./conformance/run.sh" >&2
+	echo "      TARGET_ISSUER=https://auth.absolutejs.com ./conformance/run.sh" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
Switches the planned subdomain from `oidc-conformance.absolutejs.com` (hidden purpose) to `auth.absolutejs.com` (clean branding). Same instance, three roles:

- OIDC issuer any RP can test against
- OpenID Foundation conformance suite target
- Live demo for the showcase pages

3 small text changes across `OPENID-CONFORMANCE-CERTIFICATION.md`, `conformance/README.md`, `conformance/run.sh`. Pairs with the matching change in `absolutejs/examples` to `auth/.do/app.yaml` + `auth/DEPLOY-CONFORMANCE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenID conformance certification documentation and conformance runner guidance to reference an updated hostname for the recommended public reference instance.

* **Chores**
  * Updated error messages and configuration examples to reflect the new hostname across documentation and scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/absolutejs/absolute-auth/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->