### PR TITLE
Harden RFC 9449 DPoP proof verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,9 @@ const authPlugin = await auth({
 
 With `registerDynamicClients` enabled, an RFC 7591 client becomes an agent
 registration. Approval through the existing RFC 8628 device flow creates the
-user-to-agent delegation. The agent can then use RFC 8693 token exchange to get
-a narrowed, audience-bound access token for the protected API.
+user-to-agent delegation. Send the RFC 8707 `resource` value with device
+authorization to bind the resulting token directly to the protected API, or
+use RFC 8693 token exchange when narrowing an existing user token.
 
 When `requireDpop` is enabled, the adapter accepts only an RFC 9449-bound
 access token using the `DPoP` authorization scheme, verifies its per-request
@@ -312,6 +313,24 @@ whose JWK contains private key material, oversized identifiers, and `htu`
 claims containing query or fragment components fail closed. Resource servers
 that require RFC 9449 nonces can use the nonce helpers exported by
 `@absolutejs/auth/oidc` to issue a separate resource nonce challenge.
+
+Client applications can use `createDpopClient` from `@absolutejs/auth/client`.
+It creates a non-exportable P-256 private key, signs a fresh proof for every
+request, adds `ath` and the case-sensitive `DPoP` authorization scheme when an
+access token is supplied, and retries one authorization- or resource-server
+nonce challenge. Give the two servers distinct `nonceScope` values when they
+share an origin. Redirects remain manual so credentials and proofs are never
+forwarded to an unverified location.
+
+```ts
+import { createDpopClient } from '@absolutejs/auth/client';
+
+const dpop = await createDpopClient();
+const response = await dpop.fetch(resourceUrl, {
+	dpop: { accessToken, nonceScope: protectedResource },
+	method: 'POST'
+});
+```
 
 ```ts
 app.get('/documents', ({ protectAgent }) =>

--- a/README.md
+++ b/README.md
@@ -281,8 +281,11 @@ const authPlugin = await auth({
 		resource: 'https://api.example.com',
 		scopes: ['documents:read', 'documents:write'],
 		verifyCredential: createOidcAgentCredentialVerifier({
+			// Atomically insert a hash of jkt + jti; return false on conflict.
+			consumeDpopJti: replayStore.consume,
 			issuer: 'https://auth.example.com',
 			publicJwk: signingKey.publicJwk,
+			requireDpop: true,
 			resource: 'https://api.example.com'
 		})
 	},
@@ -299,6 +302,16 @@ With `registerDynamicClients` enabled, an RFC 7591 client becomes an agent
 registration. Approval through the existing RFC 8628 device flow creates the
 user-to-agent delegation. The agent can then use RFC 8693 token exchange to get
 a narrowed, audience-bound access token for the protected API.
+
+When `requireDpop` is enabled, the adapter accepts only an RFC 9449-bound
+access token using the `DPoP` authorization scheme, verifies its per-request
+proof and `ath` token hash, and requires the proof key to match `cnf.jkt`.
+Provide `consumeDpopJti` as an atomic shared-store insertion in clustered
+deployments; returning `false` rejects a replay. Proofs without `jti`, proofs
+whose JWK contains private key material, oversized identifiers, and `htu`
+claims containing query or fragment components fail closed. Resource servers
+that require RFC 9449 nonces can use the nonce helpers exported by
+`@absolutejs/auth/oidc` to issue a separate resource nonce challenge.
 
 ```ts
 app.get('/documents', ({ protectAgent }) =>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.75.2",
+	"version": "0.75.3",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.75.1",
+	"version": "0.75.2",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.75.4",
+	"version": "0.75.5",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.75.3",
+	"version": "0.75.4",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.75.0",
+	"version": "0.75.1",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/agents/config.ts
+++ b/src/agents/config.ts
@@ -31,6 +31,9 @@ export type AgentAuthConfig = {
 	oauthGuide?: AgentOAuthGuideConfig;
 	authorizationServer: string;
 	delegationStore: AgentDelegationStore;
+	/** Advertise RFC 9728 `dpop_bound_access_tokens_required`. Keep this aligned
+	 * with a credential verifier configured with `requireDpop: true`. */
+	dpopBoundAccessTokensRequired?: boolean;
 	logoUri?: string;
 	metadataRoute?: RouteString;
 	/** Authorization-server route prefix. Defaults to `/oauth2`; used to derive
@@ -50,6 +53,7 @@ export const agentProtectedResourceMetadata = (
 	config: Pick<
 		AgentAuthConfig,
 		| 'authorizationServer'
+		| 'dpopBoundAccessTokensRequired'
 		| 'logoUri'
 		| 'resource'
 		| 'resourceName'
@@ -58,6 +62,9 @@ export const agentProtectedResourceMetadata = (
 ) => ({
 	authorization_servers: [config.authorizationServer],
 	bearer_methods_supported: ['header'],
+	...(config.dpopBoundAccessTokensRequired === true
+		? { dpop_bound_access_tokens_required: true }
+		: {}),
 	...(config.logoUri === undefined
 		? {}
 		: { resource_logo_uri: config.logoUri }),

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -12,6 +12,19 @@ type AgentAuthFailure = {
 	message: 'Agent is not authenticated' | 'Insufficient agent scopes';
 };
 
+type ProtectAgent = {
+	<AuthReturn, AuthFailReturn = never>(
+		requiredScopes: string[],
+		handleAuth: (principal: AgentPrincipal) => Promise<AuthReturn>,
+		handleAuthFail?: (error: AgentAuthFailure) => AuthFailReturn
+	): Promise<Response | AuthReturn | Awaited<AuthFailReturn>>;
+	<AuthReturn, AuthFailReturn = never>(
+		requiredScopes: string[],
+		handleAuth: (principal: AgentPrincipal) => AuthReturn,
+		handleAuthFail?: (error: AgentAuthFailure) => AuthFailReturn
+	): Promise<Response | AuthReturn | Awaited<AuthFailReturn>>;
+};
+
 const DELETE_CODE_POINT = 127;
 const HTTP_FORBIDDEN = 403;
 const HTTP_UNAUTHORIZED = 401;
@@ -97,15 +110,11 @@ export const agentAuthContextPlugin = (config?: AgentAuthConfig) =>
 		name: '@absolutejs/auth/agent-context',
 		seed: pluginDependencySeed(config)
 	})
-		.derive(({ request }) => ({
-			protectAgent: async <AuthReturn, AuthFailReturn>(
-				requiredScopes: string[],
-				handleAuth: (
-					principal: AgentPrincipal
-				) => AuthReturn | Promise<AuthReturn>,
-				handleAuthFail?: (
-					error: AgentAuthFailure
-				) => AuthFailReturn | Promise<AuthFailReturn>
+		.derive(({ request }) => {
+			const protectAgent: ProtectAgent = async (
+				requiredScopes,
+				handleAuth,
+				handleAuthFail
 			) => {
 				if (config === undefined) {
 					const failure: AgentAuthFailure = {
@@ -146,6 +155,8 @@ export const agentAuthContextPlugin = (config?: AgentAuthConfig) =>
 				}
 
 				return handleAuth(principal);
-			}
-		}))
+			};
+
+			return { protectAgent };
+		})
 		.as('global');

--- a/src/agents/oidcAdapter.ts
+++ b/src/agents/oidcAdapter.ts
@@ -3,7 +3,7 @@ import {
 	verifyJwtWithKeys,
 	type SigningKeyIdentity
 } from '../oidc/keys';
-import { verifyDpopProof } from '../oidc/dpop';
+import { verifyDpopProof, type DpopJti } from '../oidc/dpop';
 import type { AgentCredentialVerifier } from './types';
 
 const BEARER_PREFIX = 'Bearer ';
@@ -33,6 +33,7 @@ const readAudience = (audience: unknown) => {
  * agent identity while retaining `sub` as the authorizing user. */
 export const createOidcAgentCredentialVerifier = ({
 	issuer,
+	consumeDpopJti,
 	isUsedDpopJti,
 	maxDpopAgeMs,
 	publicJwk,
@@ -41,6 +42,7 @@ export const createOidcAgentCredentialVerifier = ({
 	resource
 }: {
 	issuer: string;
+	consumeDpopJti?: (jti: DpopJti) => boolean | Promise<boolean>;
 	isUsedDpopJti?: (jti: string) => boolean | Promise<boolean>;
 	maxDpopAgeMs?: number;
 	requireDpop?: boolean;
@@ -84,6 +86,7 @@ export const createOidcAgentCredentialVerifier = ({
 			if (!authorization.startsWith('DPoP ')) return undefined;
 			const proof = await verifyDpopProof({
 				accessToken: token,
+				consumeJti: consumeDpopJti,
 				htm: request.method,
 				htu: request.url,
 				isUsedJti: isUsedDpopJti,

--- a/src/authorization/protectPermission.ts
+++ b/src/authorization/protectPermission.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from 'elysia';
+import { Elysia, StatusMap, t, type ElysiaStatus } from 'elysia';
 import { getStatusFromSource } from '../session/access';
 import { sessionStore } from '../session/state';
 import { userSessionIdTypebox } from '../typebox';
@@ -19,6 +19,40 @@ type PermissionFailError =
 			readonly message: 'User is not authenticated';
 	  };
 
+type PermissionFailureResponse =
+	| ElysiaStatus<
+			'Bad Request',
+			'Cookies are missing',
+			(typeof StatusMap)['Bad Request']
+	  >
+	| ElysiaStatus<
+			'Forbidden',
+			'Insufficient permissions',
+			(typeof StatusMap)['Forbidden']
+	  >
+	| ElysiaStatus<
+			'Unauthorized',
+			'User is not authenticated',
+			(typeof StatusMap)['Unauthorized']
+	  >;
+
+type ProtectPermission<UserType> = {
+	<AuthReturn, AuthFailReturn = never>(
+		check: PermissionCheck,
+		handleAuth: (user: UserType) => Promise<AuthReturn>,
+		handleAuthFail?: (error: PermissionFailError) => AuthFailReturn
+	): Promise<
+		PermissionFailureResponse | AuthReturn | Awaited<AuthFailReturn>
+	>;
+	<AuthReturn, AuthFailReturn = never>(
+		check: PermissionCheck,
+		handleAuth: (user: UserType) => AuthReturn,
+		handleAuthFail?: (error: PermissionFailError) => AuthFailReturn
+	): Promise<
+		PermissionFailureResponse | AuthReturn | Awaited<AuthFailReturn>
+	>;
+};
+
 // RBAC/ABAC guard, usable alongside `protectRoute`. `protectPermission(check, handler)` runs the
 // handler only when the caller is authenticated AND the consumer's `hasPermission` hook approves
 // the `{ permission, organizationId }` descriptor — otherwise 401 (not authenticated) or 403
@@ -38,15 +72,11 @@ export const protectPermissionPlugin = <UserType>({
 			schema: 'merge'
 		})
 		.derive(
-			({ store: { session }, cookie: { user_session_id }, status }) => ({
-				protectPermission: <AuthReturn, AuthFailReturn>(
-					check: PermissionCheck,
-					handleAuth: (
-						user: UserType
-					) => AuthReturn | Promise<AuthReturn>,
-					handleAuthFail?: (
-						error: PermissionFailError
-					) => AuthFailReturn
+			({ store: { session }, cookie: { user_session_id }, status }) => {
+				const protectPermission: ProtectPermission<UserType> = (
+					check,
+					handleAuth,
+					handleAuthFail
 				) =>
 					getStatusFromSource<UserType>({
 						authSessionStore,
@@ -55,16 +85,16 @@ export const protectPermissionPlugin = <UserType>({
 					}).then(async ({ user, error }) => {
 						if (error) {
 							return (
-								handleAuthFail?.(error) ??
+								(await handleAuthFail?.(error)) ??
 								status(error.code, error.message)
 							);
 						}
 						if (!user) {
 							return (
-								handleAuthFail?.({
+								(await handleAuthFail?.({
 									code: 'Unauthorized',
 									message: 'User is not authenticated'
-								}) ??
+								})) ??
 								status(
 									'Unauthorized',
 									'User is not authenticated'
@@ -86,16 +116,18 @@ export const protectPermissionPlugin = <UserType>({
 							});
 
 							return (
-								handleAuthFail?.({
+								(await handleAuthFail?.({
 									code: 'Forbidden',
 									message: 'Insufficient permissions'
-								}) ??
+								})) ??
 								status('Forbidden', 'Insufficient permissions')
 							);
 						}
 
 						return handleAuth(user);
-					})
-			})
+					});
+
+				return { protectPermission };
+			}
 		)
 		.as('global');

--- a/src/client/dpop.test.ts
+++ b/src/client/dpop.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import { verifyDpopProof } from '../oidc/dpop';
+import { createDpopClient, createDpopKey, createDpopProof } from './dpop';
+
+const decodePayload = (proof: string) => {
+	const [, payload] = proof.split('.');
+	if (!payload) throw new Error('DPoP proof payload is missing');
+	const value: unknown = JSON.parse(
+		Buffer.from(payload, 'base64url').toString('utf8')
+	);
+	if (typeof value !== 'object' || value === null)
+		throw new Error('DPoP proof payload is invalid');
+
+	return value;
+};
+
+const payloadField = (proof: string, field: string) =>
+	Reflect.get(decodePayload(proof), field);
+
+describe('DPoP client', () => {
+	test('creates a non-exportable ES256 proof key and verifiable proofs', async () => {
+		const key = await createDpopKey();
+		expect(key.privateKey.extractable).toBe(false);
+		expect(key.publicJwk.d).toBeUndefined();
+		const now = 1_000_000;
+		const proof = await createDpopProof({
+			accessToken: 'bound-access-token',
+			htm: 'post',
+			htu: 'https://api.example/inbox?ignored=true#fragment',
+			jti: 'proof-1',
+			key,
+			now
+		});
+
+		expect(
+			await verifyDpopProof({
+				accessToken: 'bound-access-token',
+				htm: 'POST',
+				htu: 'https://api.example/inbox',
+				now,
+				proof
+			})
+		).toMatchObject({ jti: 'proof-1' });
+	});
+
+	test('retries one nonce challenge with a fresh proof and replayable body', async () => {
+		const requests: Request[] = [];
+		const bodies: string[] = [];
+		const client = await createDpopClient({
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const captured = request.clone();
+				requests.push(captured);
+				bodies.push(await request.text());
+
+				return requests.length === 1
+					? new Response(
+							JSON.stringify({ error: 'use_dpop_nonce' }),
+							{
+								headers: { 'DPoP-Nonce': 'resource-nonce-1' },
+								status: 401
+							}
+						)
+					: new Response(JSON.stringify({ ok: true }));
+			}
+		});
+		const response = await client.fetch(
+			'https://api.example/inbox?cursor=private',
+			{
+				body: JSON.stringify({ maximumMessages: 1 }),
+				dpop: {
+					accessToken: 'bound-access-token',
+					nonceScope: 'https://api.example/federation-inbox'
+				},
+				headers: { 'content-type': 'application/json' },
+				method: 'POST'
+			}
+		);
+
+		expect(response.ok).toBe(true);
+		expect(bodies).toEqual([
+			'{"maximumMessages":1}',
+			'{"maximumMessages":1}'
+		]);
+		expect(requests).toHaveLength(2);
+		const firstProof = requests[0]?.headers.get('dpop');
+		const secondProof = requests[1]?.headers.get('dpop');
+		if (!firstProof || !secondProof)
+			throw new Error('DPoP proof is missing');
+		expect(requests[1]?.headers.get('authorization')).toBe(
+			'DPoP bound-access-token'
+		);
+		expect(requests[1]?.redirect).toBe('manual');
+		expect(payloadField(firstProof, 'nonce')).toBeUndefined();
+		expect(payloadField(secondProof, 'nonce')).toBe('resource-nonce-1');
+		expect(payloadField(firstProof, 'jti')).not.toBe(
+			payloadField(secondProof, 'jti')
+		);
+		expect(decodePayload(secondProof)).toMatchObject({
+			htm: 'POST',
+			htu: 'https://api.example/inbox'
+		});
+	});
+});

--- a/src/client/dpop.ts
+++ b/src/client/dpop.ts
@@ -1,0 +1,184 @@
+const encoder = new TextEncoder();
+const HTTP_BAD_REQUEST = 400;
+const HTTP_UNAUTHORIZED = 401;
+const MILLISECONDS_PER_SECOND = 1000;
+
+const base64Url = (bytes: Uint8Array) => {
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+
+	return btoa(binary)
+		.replaceAll('+', '-')
+		.replaceAll('/', '_')
+		.replace(/=+$/u, '');
+};
+
+const encodeJson = (value: unknown) =>
+	base64Url(encoder.encode(JSON.stringify(value)));
+
+const normalizeHtu = (input: string | URL) => {
+	const url = new URL(input);
+	if (url.username || url.password)
+		throw new Error('DPoP request URLs cannot contain credentials');
+
+	return `${url.origin}${url.pathname}`;
+};
+
+const accessTokenHash = async (accessToken: string) =>
+	base64Url(
+		new Uint8Array(
+			await crypto.subtle.digest('SHA-256', encoder.encode(accessToken))
+		)
+	);
+
+export type DpopKey = {
+	privateKey: CryptoKey;
+	publicJwk: JsonWebKey;
+};
+
+export type CreateDpopProofInput = {
+	accessToken?: string;
+	htm: string;
+	htu: string | URL;
+	jti?: string;
+	key: DpopKey;
+	nonce?: string;
+	now?: number;
+};
+
+export type DpopRequestInit = RequestInit & {
+	dpop?: {
+		accessToken?: string;
+		nonceScope?: string;
+	};
+};
+
+export type DpopClient = {
+	fetch: (
+		input: RequestInfo | URL,
+		init?: DpopRequestInit
+	) => Promise<Response>;
+	key: DpopKey;
+};
+
+export type DpopFetch = (
+	input: RequestInfo | URL,
+	init?: RequestInit
+) => Promise<Response>;
+
+const createDpopKey = async () => {
+	const pair = await crypto.subtle.generateKey(
+		{ name: 'ECDSA', namedCurve: 'P-256' },
+		false,
+		['sign', 'verify']
+	);
+	if (!('privateKey' in pair))
+		throw new Error('WebCrypto did not produce a DPoP key pair');
+	const publicJwk = await crypto.subtle.exportKey('jwk', pair.publicKey);
+	if (
+		publicJwk.kty !== 'EC' ||
+		publicJwk.crv !== 'P-256' ||
+		!publicJwk.x ||
+		!publicJwk.y ||
+		publicJwk.d !== undefined
+	)
+		throw new Error('WebCrypto produced an invalid public DPoP key');
+
+	return Object.freeze({ privateKey: pair.privateKey, publicJwk });
+};
+
+const createDpopProof = async ({
+	accessToken,
+	htm,
+	htu,
+	jti = crypto.randomUUID(),
+	key,
+	nonce,
+	now = Date.now()
+}: CreateDpopProofInput) => {
+	const header = encodeJson({
+		alg: 'ES256',
+		jwk: key.publicJwk,
+		typ: 'dpop+jwt'
+	});
+	const payload = encodeJson({
+		...(accessToken === undefined
+			? {}
+			: { ath: await accessTokenHash(accessToken) }),
+		htm: htm.toUpperCase(),
+		htu: normalizeHtu(htu),
+		iat: Math.floor(now / MILLISECONDS_PER_SECOND),
+		jti,
+		...(nonce === undefined ? {} : { nonce })
+	});
+	const signingInput = `${header}.${payload}`;
+	const signature = await crypto.subtle.sign(
+		{ hash: 'SHA-256', name: 'ECDSA' },
+		key.privateKey,
+		encoder.encode(signingInput)
+	);
+
+	return `${signingInput}.${base64Url(new Uint8Array(signature))}`;
+};
+
+const createDpopClient = async (options?: {
+	fetch?: DpopFetch;
+	key?: DpopKey;
+}) => {
+	const requestFetch = options?.fetch ?? globalThis.fetch;
+	const key = options?.key ?? (await createDpopKey());
+	const nonces = new Map<string, string>();
+
+	const client: DpopClient = Object.freeze({
+		key,
+		fetch: async (input: RequestInfo | URL, init: DpopRequestInit = {}) => {
+			const { dpop, ...requestInit } = init;
+			const template = new Request(input, requestInit);
+			const htu = normalizeHtu(template.url);
+			const nonceScope = dpop?.nonceScope ?? htu;
+			const perform = async (nonce: string | undefined) => {
+				const headers = new Headers(template.headers);
+				headers.set(
+					'DPoP',
+					await createDpopProof({
+						accessToken: dpop?.accessToken,
+						htm: template.method,
+						htu,
+						key,
+						nonce
+					})
+				);
+				if (dpop?.accessToken)
+					headers.set('Authorization', `DPoP ${dpop.accessToken}`);
+				const response = await requestFetch(
+					new Request(template.clone(), {
+						headers,
+						redirect: 'manual'
+					})
+				);
+				const nextNonce =
+					response.headers.get('dpop-nonce') ?? undefined;
+				if (nextNonce) nonces.set(nonceScope, nextNonce);
+				const challenged =
+					response.status === HTTP_BAD_REQUEST ||
+					response.status === HTTP_UNAUTHORIZED;
+
+				return { challenged, nextNonce, response };
+			};
+			const firstNonce = nonces.get(nonceScope);
+			const first = await perform(firstNonce);
+			if (
+				!first.challenged ||
+				!first.nextNonce ||
+				first.nextNonce === firstNonce
+			)
+				return first.response;
+
+			return (await perform(first.nextNonce)).response;
+		}
+	});
+
+	return client;
+};
+
+export { createDpopClient, createDpopKey, createDpopProof };

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,5 @@
 export * from './createAuthClient';
+export * from './dpop';
 export * from './sessionExpiry';
 export * from './mobile';
 export * from './runtimeTransport';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1019,7 +1019,7 @@ export {
 	verifyDpopNonce,
 	verifyDpopProof
 } from './oidc/dpop';
-export type { DpopResult } from './oidc/dpop';
+export type { DpopJti, DpopResult } from './oidc/dpop';
 export {
 	CLIENT_ASSERTION_TYPE,
 	verifyClientAssertion,

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -165,6 +165,11 @@ const oidcSocketTicketsMigration: Migration = {
 	sql: tablesToInitSql([oauthSocketTicketsTable])
 };
 
+const oidcDeviceAudienceMigration: Migration = {
+	id: '0005_device_resource_audience',
+	sql: 'ALTER TABLE "auth_oauth_device_authorizations" ADD COLUMN IF NOT EXISTS "audience" varchar(2048);'
+};
+
 const sessionOAuthSubjectMigration: Migration = {
 	id: '0002_oauth_subject',
 	sql: [
@@ -240,7 +245,8 @@ export const blockMigrations: Record<BlockName, BlockMigrations> = {
 			]).migrations,
 			oidcResourceAudienceMigration,
 			oidcRefreshTokenFamiliesMigration,
-			oidcSocketTicketsMigration
+			oidcSocketTicketsMigration,
+			oidcDeviceAudienceMigration
 		]
 	},
 	organizations: initMigration('organizations', [

--- a/src/oidc/config.ts
+++ b/src/oidc/config.ts
@@ -678,11 +678,13 @@ export type DeviceAuthorizationResponse = {
 };
 
 export const issueDeviceAuthorization = async <UserType>({
+	audience,
 	clientId,
 	config,
 	now = Date.now(),
 	requestedScopes
 }: {
+	audience?: string;
 	clientId: string;
 	config: OidcProviderConfig<UserType>;
 	now?: number;
@@ -700,6 +702,7 @@ export const issueDeviceAuthorization = async <UserType>({
 		config.devicePollIntervalSeconds ??
 		DEFAULT_DEVICE_POLL_INTERVAL_SECONDS;
 	await config.deviceAuthorizationStore.saveDeviceAuthorization({
+		audience,
 		clientId,
 		createdAt: now,
 		deviceCodeHash: await hashToken(deviceCode),
@@ -849,6 +852,7 @@ export const exchangeDeviceCode = async <UserType>({
 		deviceCodeHash
 	);
 	const tokenSet = await issueTokenSet({
+		audience: record.audience,
 		clientId,
 		config,
 		dpopJkt,

--- a/src/oidc/dpop.ts
+++ b/src/oidc/dpop.ts
@@ -8,6 +8,7 @@ import { jwkThumbprint, verifyJwt } from './keys';
 // the private key. WorkOS does not offer this.
 
 const DEFAULT_MAX_AGE_MS = 60_000;
+const MAX_JTI_LENGTH = 128;
 const SECONDS_TO_MS = 1000;
 
 // RFC 9449 §8 — DPoP nonces. Server-issued challenge values the client must echo back in
@@ -94,26 +95,70 @@ export const verifyDpopNonce = async ({
 
 export type DpopResult = {
 	jkt: string;
-	jti?: string;
+	jti: string;
 };
 
-const decodeHeader = (segment: string) =>
-	JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+export type DpopJti = DpopResult & {
+	expiresAt: number;
+};
 
-const normalizeHtu = (value: unknown) => {
+const decodeHeader = (segment: string) => {
+	try {
+		const value: unknown = JSON.parse(
+			Buffer.from(segment, 'base64url').toString('utf8')
+		);
+
+		return typeof value === 'object' && value !== null && !Array.isArray(value)
+			? value
+			: undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+const normalizeHtu = (value: unknown, proofClaim = false) => {
 	try {
 		const url = new URL(String(value));
+		if (
+			url.username ||
+			url.password ||
+			(proofClaim && (url.search.length > 0 || url.hash.length > 0))
+		)
+			return undefined;
 
 		return `${url.origin}${url.pathname}`;
 	} catch {
-		return '';
+		return undefined;
 	}
+};
+
+const isPublicEs256Jwk = (value: unknown): value is JsonWebKey => {
+	if (typeof value !== 'object' || value === null || Array.isArray(value))
+		return false;
+	const kty = Reflect.get(value, 'kty');
+	const crv = Reflect.get(value, 'crv');
+	const xCoordinate = Reflect.get(value, 'x');
+	const yCoordinate = Reflect.get(value, 'y');
+	const privateComponent = Reflect.get(value, 'd');
+	const alg = Reflect.get(value, 'alg');
+
+	return (
+		kty === 'EC' &&
+		crv === 'P-256' &&
+		typeof xCoordinate === 'string' &&
+		xCoordinate.length > 0 &&
+		typeof yCoordinate === 'string' &&
+		yCoordinate.length > 0 &&
+		privateComponent === undefined &&
+		(alg === undefined || alg === 'ES256')
+	);
 };
 
 // Verify a DPoP proof for a request. Returns the key thumbprint (`jkt`) to bind to the token,
 // or undefined if the proof is missing/invalid/stale/replayed.
 export const verifyDpopProof = async ({
 	accessToken,
+	consumeJti,
 	htm,
 	htu,
 	isUsedJti,
@@ -122,6 +167,7 @@ export const verifyDpopProof = async ({
 	proof
 }: {
 	accessToken?: string;
+	consumeJti?: (jti: DpopJti) => boolean | Promise<boolean>;
 	htm: string;
 	htu: string;
 	isUsedJti?: (jti: string) => boolean | Promise<boolean>;
@@ -130,19 +176,24 @@ export const verifyDpopProof = async ({
 	proof: string | undefined;
 }): Promise<DpopResult | undefined> => {
 	if (proof === undefined) return undefined;
-	const [headerSegment] = proof.split('.');
+	const segments = proof.split('.');
+	if (segments.length !== 3) return undefined;
+	const [headerSegment] = segments;
 	if (headerSegment === undefined) return undefined;
 
 	const header = decodeHeader(headerSegment);
+	const publicJwk =
+		header === undefined ? undefined : Reflect.get(header, 'jwk');
 	if (
-		header?.typ !== 'dpop+jwt' ||
-		header.alg !== 'ES256' ||
-		header.jwk === undefined
+		header === undefined ||
+		Reflect.get(header, 'typ') !== 'dpop+jwt' ||
+		Reflect.get(header, 'alg') !== 'ES256' ||
+		!isPublicEs256Jwk(publicJwk)
 	) {
 		return undefined;
 	}
 
-	const verified = await verifyJwt(proof, header.jwk);
+	const verified = await verifyJwt(proof, publicJwk).catch(() => undefined);
 	if (verified === undefined) return undefined;
 
 	const { payload } = verified;
@@ -157,23 +208,32 @@ export const verifyDpopProof = async ({
 	}
 	const iatMs =
 		typeof payload.iat === 'number' ? payload.iat * SECONDS_TO_MS : 0;
-	if (
-		payload.htm !== htm ||
-		normalizeHtu(payload.htu) !== normalizeHtu(htu) ||
-		iatMs === 0 ||
-		Math.abs(now - iatMs) > maxAgeMs
-	) {
-		return undefined;
-	}
-
+	const claimedHtu = normalizeHtu(payload.htu, true);
+	const expectedHtu = normalizeHtu(htu);
 	const jti = typeof payload.jti === 'string' ? payload.jti : undefined;
 	if (
-		jti !== undefined &&
-		isUsedJti !== undefined &&
-		(await isUsedJti(jti))
+		payload.htm !== htm ||
+		claimedHtu === undefined ||
+		expectedHtu === undefined ||
+		claimedHtu !== expectedHtu ||
+		iatMs === 0 ||
+		Math.abs(now - iatMs) > maxAgeMs ||
+		jti === undefined ||
+		jti.length === 0 ||
+		jti.length > MAX_JTI_LENGTH
 	) {
 		return undefined;
 	}
 
-	return { jkt: await jwkThumbprint(header.jwk), jti };
+	const jkt = await jwkThumbprint(publicJwk);
+	if (isUsedJti !== undefined && (await isUsedJti(jti))) {
+		return undefined;
+	}
+	if (
+		consumeJti !== undefined &&
+		!(await consumeJti({ expiresAt: iatMs + maxAgeMs, jkt, jti }))
+	)
+		return undefined;
+
+	return { jkt, jti };
 };

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -7,6 +7,14 @@
  */
 export type { OidcProviderConfig } from './config';
 export {
+	extractDpopNonceClaim,
+	mintDpopNonce,
+	verifyDpopNonce,
+	verifyDpopProof,
+	type DpopJti,
+	type DpopResult
+} from './dpop';
+export {
 	generateSigningKey,
 	jwkThumbprint,
 	signJwt,

--- a/src/oidc/postgresStores.ts
+++ b/src/oidc/postgresStores.ts
@@ -135,6 +135,7 @@ export const oauthCodesTable = pgTable('auth_oauth_codes', {
 export const oauthDeviceAuthorizationsTable = pgTable(
 	'auth_oauth_device_authorizations',
 	{
+		audience: varchar('audience', { length: 2048 }),
 		client_id: varchar('client_id', { length: ID_LENGTH }).notNull(),
 		created_at_ms: bigint('created_at_ms', { mode: 'number' }).notNull(),
 		device_code_hash: varchar('device_code_hash', {
@@ -279,6 +280,7 @@ const toCodeValues = (
 });
 
 const toDeviceAuth = (row: DeviceAuthRow): DeviceAuthorization => ({
+	audience: row.audience ?? undefined,
 	clientId: row.client_id,
 	createdAt: row.created_at_ms,
 	deviceCodeHash: row.device_code_hash,
@@ -519,6 +521,7 @@ export const createPostgresDeviceAuthorizationStore = <
 	},
 	saveDeviceAuthorization: async (deviceAuthorization) => {
 		await db.insert(oauthDeviceAuthorizationsTable).values({
+			audience: deviceAuthorization.audience ?? null,
 			client_id: deviceAuthorization.clientId,
 			created_at_ms: deviceAuthorization.createdAt,
 			device_code_hash: deviceAuthorization.deviceCodeHash,

--- a/src/oidc/routes.ts
+++ b/src/oidc/routes.ts
@@ -1564,6 +1564,7 @@ export const oidcProviderRoutes = <UserType>(
 					body: t.Object({
 						client_id: t.Optional(t.String()),
 						client_secret: t.Optional(t.String()),
+						resource: t.Optional(t.String()),
 						scope: t.Optional(t.String())
 					}),
 					headers: t.Object({
@@ -1600,6 +1601,7 @@ export const oidcProviderRoutes = <UserType>(
 										client.scopes.includes(entry)
 									);
 					const response = await issueDeviceAuthorization({
+						audience: body.resource,
 						clientId: client.clientId,
 						config,
 						now: Date.now(),

--- a/src/oidc/routes.ts
+++ b/src/oidc/routes.ts
@@ -364,7 +364,7 @@ export const oidcProviderRoutes = <UserType>(
 				'dpop-nonce': fresh,
 				'www-authenticate': 'DPoP error="use_dpop_nonce"'
 			},
-			status: HTTP_UNAUTHORIZED
+			status: HTTP_BAD_REQUEST
 		});
 	};
 

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -211,6 +211,7 @@ export type SocketTicketStore = {
 export type DeviceAuthorizationStatus = 'approved' | 'denied' | 'pending';
 
 export type DeviceAuthorization = {
+	audience?: string;
 	clientId: string;
 	createdAt: number;
 	deviceCodeHash: string;

--- a/src/routes/protectRoute.ts
+++ b/src/routes/protectRoute.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from 'elysia';
+import { Elysia, StatusMap, t, type ElysiaStatus } from 'elysia';
 import { getStatusFromSource } from '../session/access';
 import { sessionStore } from '../session/state';
 import type { AuthSessionSource } from '../session/types';
@@ -20,6 +20,29 @@ type AuthFailError =
 			readonly message: 'User is not authenticated';
 	  };
 
+type AuthFailureResponse =
+	| ElysiaStatus<
+			'Bad Request',
+			'Cookies are missing',
+			(typeof StatusMap)['Bad Request']
+	  >
+	| ElysiaStatus<
+			'Unauthorized',
+			'User is not authenticated',
+			(typeof StatusMap)['Unauthorized']
+	  >;
+
+type ProtectRoute<UserType> = {
+	<AuthReturn, AuthFailReturn = never>(
+		handleAuth: (user: UserType) => Promise<AuthReturn>,
+		handleAuthFail?: (error: AuthFailError) => AuthFailReturn
+	): Promise<AuthFailureResponse | AuthReturn | Awaited<AuthFailReturn>>;
+	<AuthReturn, AuthFailReturn = never>(
+		handleAuth: (user: UserType) => AuthReturn,
+		handleAuthFail?: (error: AuthFailError) => AuthFailReturn
+	): Promise<AuthFailureResponse | AuthReturn | Awaited<AuthFailReturn>>;
+};
+
 export const protectRoutePlugin = <UserType>({
 	accessTokens,
 	authSessionStore
@@ -40,8 +63,7 @@ export const protectRoutePlugin = <UserType>({
 			async ({
 				store: { session },
 				cookie: { user_session_id },
-				headers,
-				status
+				headers
 			}) => {
 				const sessionStatus = await getStatusFromSource<UserType>({
 					authSessionStore,
@@ -63,43 +85,47 @@ export const protectRoutePlugin = <UserType>({
 						config: accessTokens
 					});
 
-				return {
-					authPrincipal,
-					protectRoute: <AuthReturn, AuthFailReturn = never>(
-						handleAuth: (
-							user: UserType
-						) => AuthReturn | Promise<AuthReturn>,
-						handleAuthFail?: (
-							error: AuthFailError
-						) => AuthFailReturn
-					) => {
-						const user = authPrincipal?.user;
-						const { error } = sessionStatus;
-						if (error) {
-							if (user) return handleAuth(user);
-
-							return (
-								handleAuthFail?.(error) ??
-								status(error.code, error.message)
-							);
-						}
-
-						if (!user) {
-							return (
-								handleAuthFail?.({
-									code: 'Unauthorized',
-									message: 'User is not authenticated'
-								}) ??
-								status(
-									'Unauthorized',
-									'User is not authenticated'
-								)
-							);
-						}
-
-						return handleAuth(user);
-					}
-				};
+				return { absoluteAuthStatus: sessionStatus, authPrincipal };
 			}
 		)
+		.derive(({ absoluteAuthStatus, authPrincipal, status }) => {
+			const protectRoute: ProtectRoute<UserType> = async (
+				handleAuth,
+				handleAuthFail
+			) => {
+				if (!absoluteAuthStatus)
+					return (
+						(await handleAuthFail?.({
+							code: 'Unauthorized',
+							message: 'User is not authenticated'
+						})) ??
+						status('Unauthorized', 'User is not authenticated')
+					);
+
+				const user = authPrincipal?.user;
+				const { error } = absoluteAuthStatus;
+				if (error) {
+					if (user) return handleAuth(user);
+
+					return (
+						(await handleAuthFail?.(error)) ??
+						status(error.code, error.message)
+					);
+				}
+
+				if (!user) {
+					return (
+						(await handleAuthFail?.({
+							code: 'Unauthorized',
+							message: 'User is not authenticated'
+						})) ??
+						status('Unauthorized', 'User is not authenticated')
+					);
+				}
+
+				return handleAuth(user);
+			};
+
+			return { protectRoute };
+		})
 		.as('global');

--- a/src/routes/stepUp.ts
+++ b/src/routes/stepUp.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from 'elysia';
+import { Elysia, StatusMap, t, type ElysiaStatus } from 'elysia';
 import { loadSessionFromSource } from '../session/access';
 import { sessionStore } from '../session/state';
 import type { AuthSessionSource } from '../session/types';
@@ -8,6 +8,25 @@ import { pluginDependencySeed } from '../pluginIdentity';
 type ReauthFailError = {
 	readonly code: 'Unauthorized';
 	readonly message: 'Recent authentication required';
+};
+
+type ReauthFailureResponse = ElysiaStatus<
+	'Unauthorized',
+	'Recent authentication required',
+	(typeof StatusMap)['Unauthorized']
+>;
+
+type RequireRecentAuth<UserType> = {
+	<AuthReturn, AuthFailReturn = never>(
+		maxAgeMs: number,
+		handleAuth: (user: UserType) => Promise<AuthReturn>,
+		handleAuthFail?: (error: ReauthFailError) => AuthFailReturn
+	): Promise<ReauthFailureResponse | AuthReturn | Awaited<AuthFailReturn>>;
+	<AuthReturn, AuthFailReturn = never>(
+		maxAgeMs: number,
+		handleAuth: (user: UserType) => AuthReturn,
+		handleAuthFail?: (error: ReauthFailError) => AuthFailReturn
+	): Promise<ReauthFailureResponse | AuthReturn | Awaited<AuthFailReturn>>;
 };
 
 // Step-up re-auth, usable alongside `protectRoute`. `requireRecentAuth(maxAgeMs, …)`
@@ -28,19 +47,17 @@ export const stepUpPlugin = <UserType>({
 			schema: 'merge'
 		})
 		.derive(
-			({ store: { session }, cookie: { user_session_id }, status }) => ({
-				requireRecentAuth: <AuthReturn, AuthFailReturn>(
-					maxAgeMs: number,
-					handleAuth: (
-						user: UserType
-					) => AuthReturn | Promise<AuthReturn>,
-					handleAuthFail?: (error: ReauthFailError) => AuthFailReturn
+			({ store: { session }, cookie: { user_session_id }, status }) => {
+				const requireRecentAuth: RequireRecentAuth<UserType> = (
+					maxAgeMs,
+					handleAuth,
+					handleAuthFail
 				) =>
 					loadSessionFromSource<UserType>({
 						authSessionStore,
 						session,
 						userSessionId: user_session_id.value
-					}).then((userSession) => {
+					}).then(async (userSession) => {
 						const authenticatedAt = userSession?.authenticatedAt;
 						const isRecent =
 							authenticatedAt !== undefined &&
@@ -48,10 +65,10 @@ export const stepUpPlugin = <UserType>({
 
 						if (!userSession || !isRecent) {
 							return (
-								handleAuthFail?.({
+								(await handleAuthFail?.({
 									code: 'Unauthorized',
 									message: 'Recent authentication required'
-								}) ??
+								})) ??
 								status(
 									'Unauthorized',
 									'Recent authentication required'
@@ -60,7 +77,9 @@ export const stepUpPlugin = <UserType>({
 						}
 
 						return handleAuth(userSession.user);
-					})
-			})
+					});
+
+				return { requireRecentAuth };
+			}
 		)
 		.as('global');

--- a/tests/agentAuth.test.ts
+++ b/tests/agentAuth.test.ts
@@ -3,6 +3,7 @@ import { Elysia } from 'elysia';
 import { hashToken } from '../src/crypto';
 import {
 	agentAuthPlugin,
+	agentProtectedResourceMetadata,
 	auth,
 	createInMemoryAgentDelegationStore,
 	createInMemoryAgentRegistrationStore,
@@ -99,6 +100,17 @@ describe('agent auth resource and guard', () => {
 			resource_name: 'Documents API',
 			scopes_supported: ['documents:read', 'documents:write']
 		});
+	});
+
+	test('advertises when a resource requires DPoP-bound access tokens', () => {
+		expect(
+			agentProtectedResourceMetadata({
+				authorizationServer: ISSUER,
+				dpopBoundAccessTokensRequired: true,
+				resource: RESOURCE,
+				scopes: ['documents:read']
+			})
+		).toMatchObject({ dpop_bound_access_tokens_required: true });
 	});
 
 	test('resolves a delegated agent and intersects delegation scopes', async () => {

--- a/tests/clientDpop.test.ts
+++ b/tests/clientDpop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { verifyDpopProof } from '../oidc/dpop';
-import { createDpopClient, createDpopKey, createDpopProof } from './dpop';
+import { createDpopClient, createDpopKey, createDpopProof } from '../src/client/dpop';
+import { verifyDpopProof } from '../src/oidc/dpop';
 
 const decodePayload = (proof: string) => {
 	const [, payload] = proof.split('.');

--- a/tests/oidcDpop.test.ts
+++ b/tests/oidcDpop.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test';
+import { verifyDpopProof } from '../src/oidc/dpop';
+import { generateSigningKey, toPublicJwk } from '../src/oidc/keys';
+
+const HTU = 'https://resource.example.test/messages';
+
+const buildProof = async ({
+	headerJwk,
+	htu = HTU,
+	jti = crypto.randomUUID(),
+	key
+}: {
+	headerJwk?: JsonWebKey;
+	htu?: string;
+	jti?: string | null;
+	key: Awaited<ReturnType<typeof generateSigningKey>>;
+}) => {
+	const encode = (value: unknown) =>
+		Buffer.from(JSON.stringify(value)).toString('base64url');
+	const header = encode({
+		alg: 'ES256',
+		jwk: headerJwk ?? toPublicJwk(key),
+		typ: 'dpop+jwt'
+	});
+	const payload = encode({
+		htm: 'POST',
+		htu,
+		iat: Math.floor(Date.now() / 1000),
+		...(jti === null ? {} : { jti })
+	});
+	if (!('privateJwk' in key)) throw new Error('Expected an exportable key');
+	const signingKey = await crypto.subtle.importKey(
+		'jwk',
+		key.privateJwk,
+		{ name: 'ECDSA', namedCurve: 'P-256' },
+		false,
+		['sign']
+	);
+	const signature = await crypto.subtle.sign(
+		{ hash: 'SHA-256', name: 'ECDSA' },
+		signingKey,
+		new TextEncoder().encode(`${header}.${payload}`)
+	);
+
+	return `${header}.${payload}.${Buffer.from(signature).toString('base64url')}`;
+};
+
+describe('DPoP proof verification (RFC 9449)', () => {
+	test('atomically consumes the required jti after validating the proof', async () => {
+		const key = await generateSigningKey();
+		const proof = await buildProof({ key });
+		const consumed: string[] = [];
+		const result = await verifyDpopProof({
+			htm: 'POST',
+			htu: HTU,
+			proof,
+			consumeJti: async ({ jti }) => {
+				if (consumed.includes(jti)) return false;
+				consumed.push(jti);
+
+				return true;
+			}
+		});
+
+		expect(result?.jti).toBe(consumed[0]);
+		expect(
+			await verifyDpopProof({
+				htm: 'POST',
+				htu: HTU,
+				proof,
+				consumeJti: async ({ jti }) => !consumed.includes(jti)
+			})
+		).toBeUndefined();
+	});
+
+	test('rejects missing and oversized jti claims', async () => {
+		const key = await generateSigningKey();
+
+		expect(
+			await verifyDpopProof({
+				htm: 'POST',
+				htu: HTU,
+				proof: await buildProof({ jti: null, key })
+			})
+		).toBeUndefined();
+		expect(
+			await verifyDpopProof({
+				htm: 'POST',
+				htu: HTU,
+				proof: await buildProof({ jti: 'x'.repeat(129), key })
+			})
+		).toBeUndefined();
+	});
+
+	test('rejects query-bearing htu claims and private proof keys', async () => {
+		const key = await generateSigningKey();
+		if (!('privateJwk' in key)) throw new Error('Expected an exportable key');
+
+		expect(
+			await verifyDpopProof({
+				htm: 'POST',
+				htu: `${HTU}?page=1`,
+				proof: await buildProof({ htu: `${HTU}?page=1`, key })
+			})
+		).toBeUndefined();
+		expect(
+			await verifyDpopProof({
+				htm: 'POST',
+				htu: HTU,
+				proof: await buildProof({ headerJwk: key.privateJwk, key })
+			})
+		).toBeUndefined();
+	});
+
+	test('fails closed rather than throwing for malformed JOSE input', async () => {
+		expect(
+			await verifyDpopProof({
+				htm: 'POST',
+				htu: HTU,
+				proof: 'not-json.payload.signature'
+			})
+		).toBeUndefined();
+	});
+});

--- a/tests/oidcDpopNonce.test.ts
+++ b/tests/oidcDpopNonce.test.ts
@@ -23,7 +23,7 @@ const SESSION_ID: UserSessionId = '11111111-1111-4111-8111-111111111111';
 const VERIFIER = 'pkce-verifier-0123456789-abcdefghij-0123456789';
 const HOUR_MS = 3_600_000;
 const HTTP_OK = 200;
-const HTTP_UNAUTHORIZED = 401;
+const HTTP_BAD_REQUEST = 400;
 
 const buildDpopProof = async ({
 	htu,
@@ -153,7 +153,7 @@ describe('OIDC provider — DPoP nonce enforcement at /token', () => {
 		return new URL(location).searchParams.get('code') ?? '';
 	};
 
-	test('first DPoP request without nonce → 401 + DPoP-Nonce header', async () => {
+	test('first DPoP request without nonce → 400 + DPoP-Nonce header', async () => {
 		const app = await buildApp();
 		const code = await getCode(app);
 		const dpopKey = await generateSigningKey();
@@ -175,7 +175,7 @@ describe('OIDC provider — DPoP nonce enforcement at /token', () => {
 				method: 'POST'
 			})
 		);
-		expect(response.status).toBe(HTTP_UNAUTHORIZED);
+		expect(response.status).toBe(HTTP_BAD_REQUEST);
 		expect(response.headers.get('dpop-nonce')).toBeTruthy();
 		expect(response.headers.get('www-authenticate')).toContain(
 			'use_dpop_nonce'

--- a/tests/oidcProvider.test.ts
+++ b/tests/oidcProvider.test.ts
@@ -758,6 +758,7 @@ describe('OIDC provider — RFC 8628 device authorization', () => {
 			new Request('http://localhost/oauth2/device_authorization', {
 				body: new URLSearchParams({
 					client_id: 'app1',
+					resource: 'https://api.example/federation-inbox',
 					scope: 'openid profile'
 				}),
 				method: 'POST'
@@ -808,6 +809,9 @@ describe('OIDC provider — RFC 8628 device authorization', () => {
 			await app.handle(new Request('http://localhost/oauth2/jwks'))
 		).json();
 		const decoded = await verifyJwt(tokens.access_token, jwks.keys[0]);
+		expect(decoded?.payload.aud).toBe(
+			'https://api.example/federation-inbox'
+		);
 		expect(decoded?.payload.sub).toBe('user-alice');
 
 		// 5. Single-use: a second exchange with the same device_code fails.

--- a/tests/protectRouteInference.test.ts
+++ b/tests/protectRouteInference.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia, StatusMap } from 'elysia';
+import { createAuthContext } from '../src/authContext';
+import { createInMemoryAuthSessionStore } from '../src/session/inMemoryStore';
+import { protectRoutePlugin } from '../src/routes/protectRoute';
+
+type TestUser = {
+	id: string;
+};
+
+type Equal<Left, Right> =
+	(<Value>() => Value extends Left ? 1 : 2) extends <
+		Value
+	>() => Value extends Right ? 1 : 2
+		? true
+		: false;
+
+type Expect<Condition extends true> = Condition;
+
+const createInferenceApplication = () =>
+	new Elysia()
+		.use(
+			protectRoutePlugin<TestUser>({
+				authSessionStore: createInMemoryAuthSessionStore<TestUser>()
+			})
+		)
+		.get('/sync', ({ protectRoute }) =>
+			protectRoute((user) => ({ id: user.id }))
+		)
+		.get('/async', ({ protectRoute }) =>
+			protectRoute(async (user) => ({ id: user.id }))
+		);
+
+const createPlainInferenceApplication = () =>
+	new Elysia().get('/plain', () => ({ id: 'plain' }));
+
+const createComposedInferenceApplication = () =>
+	new Elysia()
+		.use(
+			createAuthContext<TestUser>({
+				authSessionStore: createInMemoryAuthSessionStore<TestUser>()
+			})
+		)
+		.get('/composed', ({ protectRoute }) =>
+			protectRoute(async (user) => ({ id: user.id }))
+		);
+
+type InferenceRoutes = ReturnType<typeof createInferenceApplication>['~Routes'];
+
+export type SyncSuccessInference = Expect<
+	Equal<
+		InferenceRoutes['sync']['get']['response'][(typeof StatusMap)['OK']],
+		{ id: string }
+	>
+>;
+
+export type PlainSuccessInference = Expect<
+	Equal<
+		ReturnType<
+			typeof createPlainInferenceApplication
+		>['~Routes']['plain']['get']['response'][(typeof StatusMap)['OK']],
+		{ id: string }
+	>
+>;
+
+export type AsyncSuccessInference = Expect<
+	Equal<
+		InferenceRoutes['async']['get']['response'][(typeof StatusMap)['OK']],
+		{ id: string }
+	>
+>;
+
+type ComposedInferenceRoutes = ReturnType<
+	typeof createComposedInferenceApplication
+>['~Routes'];
+
+export type ComposedSuccessInference = Expect<
+	Equal<
+		ComposedInferenceRoutes['composed']['get']['response'][(typeof StatusMap)['OK']],
+		{ id: string }
+	>
+>;
+
+describe('protectRoute inference', () => {
+	test('preserves synchronous and asynchronous success responses', () => {
+		const application = createInferenceApplication();
+		const composedApplication = createComposedInferenceApplication();
+		const plainApplication = createPlainInferenceApplication();
+
+		expect(application).toBeDefined();
+		expect(composedApplication).toBeDefined();
+		expect(plainApplication).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary
- require bounded DPoP proof jti values and reject private proof keys or invalid htu claims
- add atomic shared-store replay consumption for clustered resource servers
- correct RFC 9449 authorization-server nonce challenges to HTTP 400
- advertise mandatory DPoP with RFC 9728 protected-resource metadata
- add a browser-safe P-256 DPoP client with non-exportable keys, fresh proofs, separate nonce scopes, one nonce retry, access-token hashing, and redirect blocking
- carry RFC 8707 resource audiences through RFC 8628 device authorization and add the package-owned `oidc/0005_device_resource_audience` migration

## Verification
- `bun run check:package`
- 592 tests passed; 3 PostgreSQL integration tests skipped without a local database
- published tarball verified with client tests excluded

Published as `@absolutejs/auth@0.75.4`.