### PR TITLE
Fix PostgreSQL array migration defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.75.5",
+	"version": "0.75.6",
 	"name": "@absolutejs/auth",
 	"description": "An authorization library for absolutejs",
 	"repository": {

--- a/src/migrations/generate.ts
+++ b/src/migrations/generate.ts
@@ -31,19 +31,6 @@ const renderChunk = (chunk: unknown) => {
 const formatSqlTemplate = (value: SQL) =>
 	value.queryChunks.map(renderChunk).join('');
 
-const formatDefault = (value: unknown) => {
-	if (value === null || value === undefined) return 'NULL';
-	if (is(value, SQL)) return formatSqlTemplate(value);
-	if (typeof value === 'string') return `'${value.replace(/'/gu, "''")}'`;
-	if (typeof value === 'boolean') return value ? 'true' : 'false';
-	if (typeof value === 'number') return String(value);
-	if (Array.isArray(value) || typeof value === 'object') {
-		return `'${JSON.stringify(value)}'::jsonb`;
-	}
-
-	return String(value);
-};
-
 /**
  * The column's SQL type, brackets included.
  *
@@ -64,12 +51,48 @@ const columnSqlType = (column: PgColumn) => {
 		: elementType;
 };
 
+const formatScalarDefault = (value: unknown) => {
+	if (value === null || value === undefined) return 'NULL';
+	if (is(value, SQL)) return formatSqlTemplate(value);
+	if (typeof value === 'string') return `'${value.replace(/'/gu, "''")}'`;
+	if (typeof value === 'boolean') return value ? 'true' : 'false';
+	if (typeof value === 'number') return String(value);
+	if (typeof value === 'object') {
+		return `'${JSON.stringify(value)}'::jsonb`;
+	}
+
+	return String(value);
+};
+
+type FormatArrayDefault = (values: unknown[]) => string;
+
+const formatArrayDefault: FormatArrayDefault = (values) =>
+	`ARRAY[${values
+		.map((value) =>
+			Array.isArray(value)
+				? formatArrayDefault(value)
+				: formatScalarDefault(value)
+		)
+		.join(', ')}]`;
+
+const formatDefault = (column: PgColumn, value: unknown) => {
+	const dimensions = Reflect.get(column, 'dimensions');
+	if (
+		Array.isArray(value) &&
+		typeof dimensions === 'number' &&
+		dimensions > 0
+	)
+		return `${formatArrayDefault(value)}::${columnSqlType(column)}`;
+
+	return formatScalarDefault(value);
+};
+
 const columnSql = (column: PgColumn) => {
 	const parts = [`"${column.name}"`, columnSqlType(column)];
 	if (column.primary) parts.push('PRIMARY KEY');
 	if (column.notNull && !column.primary) parts.push('NOT NULL');
 	if (column.hasDefault && column.default !== undefined) {
-		parts.push(`DEFAULT ${formatDefault(column.default)}`);
+		parts.push(`DEFAULT ${formatDefault(column, column.default)}`);
 	}
 	if (column.isUnique) parts.push('UNIQUE');
 

--- a/tests/migrationArrayColumns.test.ts
+++ b/tests/migrationArrayColumns.test.ts
@@ -35,4 +35,42 @@ describe('array columns in generated DDL', () => {
 
 		expect(sql).toContain('"grid" integer[][] NOT NULL');
 	});
+
+	test('casts empty PostgreSQL array defaults to the column type', () => {
+		const sql = tablesToInitSql([
+			pgTable('probe', {
+				consumed: text('consumed').array().notNull().default([])
+			})
+		]);
+
+		expect(sql).toContain(
+			'"consumed" text[] NOT NULL DEFAULT ARRAY[]::text[]'
+		);
+		expect(sql).not.toContain("DEFAULT '[]'::jsonb");
+	});
+
+	test('renders populated and nested PostgreSQL array defaults', () => {
+		const sql = tablesToInitSql([
+			pgTable('probe', {
+				grid: integer('grid')
+					.array('[][]')
+					.notNull()
+					.default([
+						[1, 2],
+						[2, 1]
+					]),
+				labels: text('labels')
+					.array()
+					.notNull()
+					.default(["owner's", 'custodian'])
+			})
+		]);
+
+		expect(sql).toContain(
+			'"grid" integer[][] NOT NULL DEFAULT ARRAY[ARRAY[1, 2], ARRAY[2, 1]]::integer[][]'
+		);
+		expect(sql).toContain(
+			"\"labels\" text[] NOT NULL DEFAULT ARRAY['owner''s', 'custodian']::text[]"
+		);
+	});
 });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -77,6 +77,16 @@ describe('blockMigrations manifest', () => {
 		expect(deferred?.sql).toContain('"registration_data" jsonb');
 	});
 
+	test('OIDC initializes refresh-token hash arrays with a PostgreSQL array default', () => {
+		const oidcInit = blockMigrations.oidc.migrations.find(
+			(migration) => migration.id === '0001_init'
+		);
+
+		expect(oidcInit?.sql).toContain(
+			'"consumed_token_hashes" text[] NOT NULL DEFAULT ARRAY[]::text[]'
+		);
+	});
+
 	test('every block names tables prefixed with auth_ or a known package prefix', () => {
 		// Catches accidental cross-package collision; intent + similar consumers will own
 		// any non-`auth_` namespace and we shouldn't ship migrations that touch theirs.
@@ -147,7 +157,7 @@ const migrationDatabaseUrl = process.env['MIGRATION_TEST_DATABASE_URL'];
 describe.skipIf(migrationDatabaseUrl === undefined)(
 	'runMigrations Postgres integration',
 	() => {
-		test('applies and journals migrations through an injected Bun SQL client', async () => {
+		test('applies every migration and journals an idempotent rerun', async () => {
 			if (migrationDatabaseUrl === undefined)
 				throw new Error('MIGRATION_TEST_DATABASE_URL is required');
 			const sql = new SQL({
@@ -163,22 +173,43 @@ describe.skipIf(migrationDatabaseUrl === undefined)(
 
 			try {
 				const first = await runMigrations({
-					blocks: ['vault'],
 					client,
 					log: () => undefined
 				});
 				const second = await runMigrations({
-					blocks: ['vault'],
 					client,
 					log: () => undefined
 				});
-				const [table] = await sql<
-					Array<{ table_name: string | null }>
-				>`SELECT to_regclass('public.auth_vault_entries')::text AS table_name`;
+				const expectedIds = Object.entries(blockMigrations).flatMap(
+					([blockName, block]) =>
+						block.migrations.map(
+							(migration) => `${blockName}/${migration.id}`
+						)
+				);
+				const [columns] = await sql<
+					Array<{
+						column_default: string | null;
+						data_type: string;
+						vault_table: string | null;
+					}>
+				>`SELECT
+					(SELECT column_default FROM information_schema.columns
+						WHERE table_schema = 'public'
+							AND table_name = 'auth_oauth_refresh_tokens'
+							AND column_name = 'consumed_token_hashes') AS column_default,
+					(SELECT data_type FROM information_schema.columns
+						WHERE table_schema = 'public'
+							AND table_name = 'auth_oauth_refresh_tokens'
+							AND column_name = 'consumed_token_hashes') AS data_type,
+					to_regclass('public.auth_vault_entries')::text AS vault_table`;
 
-				expect(first.applied).toEqual(['vault/0001_init']);
-				expect(second.skipped).toContain('vault/0001_init');
-				expect(table?.table_name).toBe('auth_vault_entries');
+				expect(first.applied).toEqual(expectedIds);
+				expect(second.skipped).toEqual(expectedIds);
+				expect(columns).toEqual({
+					column_default: 'ARRAY[]::text[]',
+					data_type: 'ARRAY',
+					vault_table: 'auth_vault_entries'
+				});
 			} finally {
 				await sql.close();
 			}


### PR DESCRIPTION
Fix generated PostgreSQL array defaults so typed array columns no longer receive JSONB defaults. Adds unit coverage for empty, populated, nested, and escaped array values plus a fresh-database migration and idempotency regression. Published as @absolutejs/auth 0.75.6 after the complete local release gate and fresh PostgreSQL verification passed.